### PR TITLE
RM-1456 Add & as valid in SG rule descriptions

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -1563,7 +1563,9 @@ func validateSecurityGroupRuleDescription(v interface{}, k string) (ws []string,
 
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html. Note that
 	// "" is an allowable description value.
-	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*]*$`
+	//
+	// Note that & is allowed, but not documented.
+	pattern := `^[A-Za-z0-9 \.\_\-\:\/\(\)\#\,\@\[\]\+\=\;\{\}\!\$\*\&]*$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",


### PR DESCRIPTION
Amazon documentation says that '&' is not a valid character in Security Group rule descriptions, however the console allows using '&'. The terraform-aws-provider has a validation to ensure that
descriptions match the documented allowed characters, which causes errors when dealing with rules created outside of terraform that include '&'.

This updates the Security Group rule description validator to allow the use of '&'.