### PR TITLE
[RM-1480] Suppress InvalidVpcID.NotFound on describe VPC classic link calls

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -229,6 +229,8 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "UnsupportedOperation" {
 			log.Printf("[WARN] VPC Classic Link is not supported in this region")
+		} else if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+			log.Printf("[WARN] InvalidVpcID.NotFound on DescribeVpcClassicLink")
 		} else {
 			return err
 		}
@@ -254,6 +256,8 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		if isAWSErr(err, "UnsupportedOperation", "The functionality you requested is not available in this region") ||
 			isAWSErr(err, "AuthFailure", "This request has been administratively disabled") {
 			log.Printf("[WARN] VPC Classic Link DNS Support is not supported in this region")
+		} else if isAWSErr(err, "InvalidVpcID.NotFound", "") {
+			log.Printf("[WARN] InvalidVpcID.NotFound on DescribeVpcClassicLinkDnsSupport")
 		} else {
 			return err
 		}


### PR DESCRIPTION
# Why

Some VPCs incorrectly fail to refresh due to `InvalidVpcID.NotFound`.

# What

In some research I found a potential cause that cropped up for other people: describe VPC classic link calls can fail with this:

https://github.com/ansible/ansible/issues/36083

This PR suppresses the error on `DescribeVpcClassicLink` and `DescribeVpcClassicLinkDnsSupport` which are made to set the *optional* attributes `enable_classiclink` and `enable_classiclink_dns_support`.

https://www.terraform.io/docs/providers/aws/r/vpc.html#enable_classiclink

The provider already suppresses `UnsupportedOperation` for both of these calls, but my suspicion is AWS may also return VPC not found in certain cases.

 