### PR TITLE
RM-1551 Check for nil values when hashing launch specifications

### DIFF
--- a/aws/resource_aws_acm_certificate_validation.go
+++ b/aws/resource_aws_acm_certificate_validation.go
@@ -90,7 +90,7 @@ func resourceAwsAcmCertificateCheckValidationRecords(validationRecordFqdns []int
 			CertificateArn: cert.CertificateArn,
 		}
 		err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", cert.CertificateArn)
+			log.Printf("[DEBUG] Certificate domain validation options empty for %q, retrying", *cert.CertificateArn)
 			output, err := conn.DescribeCertificate(input)
 			if err != nil {
 				return resource.NonRetryableError(err)

--- a/aws/resource_aws_api_gateway_resource_test.go
+++ b/aws/resource_aws_api_gateway_resource_test.go
@@ -84,7 +84,7 @@ func TestAccAWSAPIGatewayResource_update(t *testing.T) {
 func testAccCheckAWSAPIGatewayResourceAttributes(conf *apigateway.Resource, path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if *conf.Path != path {
-			return fmt.Errorf("Wrong Path: %q", conf.Path)
+			return fmt.Errorf("Wrong Path: %q", *conf.Path)
 		}
 
 		return nil

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1210,14 +1210,18 @@ func hashLaunchSpecification(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
-	if m["availability_zone"] != "" {
+	if _, ok := m["availability_zone"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", m["availability_zone"].(string)))
 	}
-	if m["subnet_id"] != "" {
+	if _, ok := m["subnet_id"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", m["subnet_id"].(string)))
 	}
-	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
+	if _, ok := m["instance_type"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
+	}
+	if _, ok := m["spot_price"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
+	}
 	return hashcode.String(buf.String())
 }
 

--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -1209,7 +1209,9 @@ func hashRootBlockDevice(v interface{}) int {
 func hashLaunchSpecification(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
+	if _, ok := m["ami"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", m["ami"].(string)))
+	}
 	if _, ok := m["availability_zone"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", m["availability_zone"].(string)))
 	}

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -622,7 +622,7 @@ func testAccCheckAWSSpotFleetRequest_PlacementAttributes(
 			return fmt.Errorf("Expected placement to be set, got nil")
 		}
 		if *placement.Tenancy != "dedicated" {
-			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", placement.Tenancy)
+			return fmt.Errorf("Expected placement tenancy to be %q, got %q", "dedicated", *placement.Tenancy)
 		}
 
 		return nil


### PR DESCRIPTION
# WHY
Terraform panics when hasing spot fleet request launch specifications without certain fields

# WHAT
Check for nil values when hashing launch specifications

- [x] Tested locally
https://luminal.atlassian.net/browse/RM-1551