### PR TITLE
Pluck changes from this PR in the main TF repo:

### DIFF
--- a/aws/resource_aws_db_instance.go
+++ b/aws/resource_aws_db_instance.go
@@ -403,6 +403,8 @@ func resourceAwsDbInstance() *schema.Resource {
 						"listener",
 						"slowquery",
 						"trace",
+						"postgresql",
+						"upgrade",
 					}, false),
 				},
 			},


### PR DESCRIPTION
# Why

Drift detection fails with:

```
{
  "errorMessage": "Terraform error Failed to execute terraform plan: terraform error: \nError: aws_db_instance.dGVycmFmb3JtLTIwMTkwMzAzMjAyNDQ4MTYwNzAwMDAwMDAx: expected enabled_cloudwatch_logs_exports.0 to be one of [alert audit error general listener slowquery trace], got postgresql\n\n\n\nError: aws_db_instance.dGVycmFmb3JtLTIwMTkwMzAzMjAyNDQ4MTYwNzAwMDAwMDAx: expected enabled_cloudwatch_logs_exports.1 to be one of [alert audit error general listener slowquery trace], got upgrade\n\n\n (exit status 1)",
  "errorType": "ScanTerraformError"
}
```

# What

Plucks changes from a more recent Terraform version. See PR 6829 in TF AWS provider.

# JIRA

RM-1538