### PR TITLE
[RM-1604] Mark aws_kms_grant.grantee_principal as optional

### DIFF
--- a/aws/resource_aws_kms_grant.go
+++ b/aws/resource_aws_kms_grant.go
@@ -39,7 +39,7 @@ func resourceAwsKmsGrant() *schema.Resource {
 			},
 			"grantee_principal": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateArn,
 			},


### PR DESCRIPTION
This field is required, but in some cases it may not be included in the
scan result; possibly due to eventual consistency issues with IAM
principals.

Marking it as optional fixes the scan error where we see:

    {
      "errorMessage": "Terraform error Failed to execute terraform plan: terraform error: Error: aws_kms_grant....: \"grantee_principal\": required field is not set Error: aws_kms_grant....: \"grantee_principal\": required field is not set (exit status 1)",
      "errorType": "ScanTerraformError"
    }