### PR TITLE
RM-1709 Fix NPE on ENIs owned by another account

### DIFF
--- a/aws/resource_aws_network_interface.go
+++ b/aws/resource_aws_network_interface.go
@@ -179,7 +179,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	// Tags
 	d.Set("tags", tagsToMap(eni.TagSet))
 
-	if eni.Attachment != nil {
+	if eni.Attachment != nil && eni.Attachment.DeviceIndex != nil && eni.Attachment.AttachmentId != nil {
 		attachment := []map[string]interface{}{flattenAttachment(eni.Attachment)}
 		d.Set("attachment", attachment)
 	} else {


### PR DESCRIPTION
A customer scan started failing with the following nil pointer exception when surveying an ENI created in a shared subnet. @curtis-fugue was able to reproduce it by sharing a subnet from account A to account B. In account B, I created an EC2 instance in that subnet. The instances ENI then shows up in account A with the following attachment:

    "Attachment": {
      "AttachTime": "2019-04-09T19:59:57.000Z",
      "Status": "attached"
    },

This is missing the required DeviceIndex and AttachmentId fields, which causes the read method for aws_network_interface to crash with a nil pointer exception. This updates the read method to exclude
attachments that do not include these fields.
