### PR TITLE
[BUG] [RM-1742] Allow Intelligent Tiering Lifecycle Setting

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -391,6 +391,7 @@ func resourceAwsS3Bucket() *schema.Resource {
 														s3.StorageClassOnezoneIa,
 														s3.StorageClassStandardIa,
 														s3.StorageClassReducedRedundancy,
+														"INTELLIGENT_TIERING",
 													}, false),
 												},
 												"replica_kms_key_id": {

--- a/aws/resource_aws_s3_bucket_object.go
+++ b/aws/resource_aws_s3_bucket_object.go
@@ -108,6 +108,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 					s3.StorageClassReducedRedundancy,
 					s3.StorageClassOnezoneIa,
 					s3.StorageClassStandardIa,
+					"INTELLIGENT_TIERING",
 				}, false),
 			},
 

--- a/aws/validators.go
+++ b/aws/validators.go
@@ -609,6 +609,7 @@ func validateS3BucketLifecycleStorageClass() schema.SchemaValidateFunc {
 		s3.TransitionStorageClassOnezoneIa,
 		s3.TransitionStorageClassStandardIa,
 		s3.TransitionStorageClassGlacier,
+		"INTELLIGENT_TIERING",
 	}, false)
 }
 


### PR DESCRIPTION
## What
Fixes drift error:
```{"errorMessage":"Terraform` error Failed to execute terraform plan: terraform error: \nError: aws_s3_bucket...: expected lifecycle_rule.0.transition.0.storage_class to be one of [ONEZONE_IA STANDARD_IA GLACIER], got INTELLIGENT_TIERING\n\n\n\nError: aws_s3_bucket...: expected lifecycle_rule.0.transition.0.storage_class to be one of [ONEZONE_IA STANDARD_IA GLACIER], got INTELLIGENT_TIERING\n\n\n (exit status 1)","errorType":"ScanTerraformError"}```

## Why
AWS recently introduced a new Lifecycle Management setting to S3 called Intelligent Tiering.  
Terraform v1.51.0 included a fix for allowing this.  
Here we've just selectively used the updated code and kept it as a string because our AWS SDK doesn't have the new properties, yet.
