### PR TITLE
update validators.validateCIDRNetworkAddress to suppress cidr network checks

### DIFF
--- a/aws/validators.go
+++ b/aws/validators.go
@@ -486,17 +486,22 @@ func validatePolicyStatementId(v interface{}, k string) (ws []string, errors []e
 // represents a network address - it adds an error otherwise
 func validateCIDRNetworkAddress(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	_, ipnet, err := net.ParseCIDR(value)
+	// _, ipnet, err := net.ParseCIDR(value)
+	_, _, err := net.ParseCIDR(value)
 	if err != nil {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain a valid CIDR, got error parsing: %s", k, err))
 		return
 	}
 
-	if ipnet == nil || value != ipnet.String() {
-		errors = append(errors, fmt.Errorf(
-			"%q must contain a valid network CIDR, got %q", k, value))
-	}
+	// REMOVED: (eric-luminal) removed for being overly strict when validating
+	// older resources that may have been allowed to be created with non-network
+	// CIDRS
+
+	// if ipnet == nil || value != ipnet.String() {
+	// 	errors = append(errors, fmt.Errorf(
+	// 		"%q must contain a valid network CIDR, got %q", k, value))
+	// }
 
 	return
 }


### PR DESCRIPTION
# What
Suppresses CIDR validations to only check string validity and skips checking if the provided CIDR is the network address

# Why
It appears that AWS did not always force a CIDR to be a network address and implicitly figured it out from what ever CIDR was passed. When importing existing environments that have these invalid CIDRS we do not want to fail on plan.