### PR TITLE
update launch configs to only use user_data_base64

### DIFF
--- a/aws/resource_aws_launch_configuration.go
+++ b/aws/resource_aws_launch_configuration.go
@@ -541,12 +541,10 @@ func resourceAwsLaunchConfigurationRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("error setting security_groups: %s", err)
 	}
 	if v := aws.StringValue(lc.UserData); v != "" {
-		_, b64 := d.GetOk("user_data_base64")
-		if b64 {
-			d.Set("user_data_base64", v)
-		} else {
-			d.Set("user_data", userDataHashSum(v))
-		}
+		// Always use `user_data_base64`. Otherwise we will always
+		// register drift as we will be comparing a hash (.tfstate)
+		// to a hash of the past (.tf.json).
+		d.Set("user_data_base64", v)
 	}
 
 	d.Set("vpc_classic_link_id", lc.ClassicLinkVPCId)


### PR DESCRIPTION
# What
forces launch configurations reads to put user data into the `user_data_base64` terraform state parameter

# Why
using the default of `user_data` causes drift issues as it is stored as a hash that is different between refreshes.

# Jira
https://luminal.atlassian.net/browse/RM-2151