### PR TITLE
[RM-2205] update aws_lb_target_group timeout constraint check

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -191,7 +191,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.IntBetween(2, 60),
+							ValidateFunc: validation.IntBetween(2, 120),
 						},
 
 						"healthy_threshold": {


### PR DESCRIPTION
# What
update aws_lb_target_group timeout constraint check

# Why
The value can actually go as high as 120 now