### PR TITLE
[RM-2311] allow for newer engine modes in rds clusters

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -126,6 +126,8 @@ func resourceAwsRDSCluster() *schema.Resource {
 				ForceNew: true,
 				Default:  "provisioned",
 				ValidateFunc: validation.StringInSlice([]string{
+					"global",        // (eric-luminal) backported
+					"parallelquery", // (eric-luminal) backported
 					"provisioned",
 					"serverless",
 				}, false),


### PR DESCRIPTION
# What
backports some newer rds engine modes from our forked code line

# Why
the application's constraints need to be updated