### PR TITLE
Switch API GW deployment stage name to optional given our usage

### DIFF
--- a/aws/resource_aws_api_gateway_deployment.go
+++ b/aws/resource_aws_api_gateway_deployment.go
@@ -28,8 +28,10 @@ func resourceAwsApiGatewayDeployment() *schema.Resource {
 			},
 
 			"stage_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type: schema.TypeString,
+				// Switched to optional for RM-2025
+				// Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 


### PR DESCRIPTION
# Why

There are cases where this empty in our use case.