### PR TITLE
Disable cognito user pool schema for users

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -282,90 +282,6 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 				},
 			},
 
-			"schema": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				ForceNew: true,
-				MinItems: 1,
-				MaxItems: 50,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute_data_type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								cognitoidentityprovider.AttributeDataTypeString,
-								cognitoidentityprovider.AttributeDataTypeNumber,
-								cognitoidentityprovider.AttributeDataTypeDateTime,
-								cognitoidentityprovider.AttributeDataTypeBoolean,
-							}, false),
-						},
-						"developer_only_attribute": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"mutable": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"name": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validateCognitoUserPoolSchemaName,
-						},
-						"number_attribute_constraints": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"min_value": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-									},
-									"max_value": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-									},
-								},
-							},
-						},
-						"required": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-						},
-						"string_attribute_constraints": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"min_length": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-									},
-									"max_length": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ForceNew: true,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-
 			"sms_authentication_message": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -559,11 +475,6 @@ func resourceAwsCognitoUserPoolCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	if v, ok := d.GetOk("schema"); ok {
-		configs := v.(*schema.Set).List()
-		params.Schema = expandCognitoUserPoolSchema(configs)
-	}
-
 	if v, ok := d.GetOk("sms_authentication_message"); ok {
 		params.SmsAuthenticationMessage = aws.String(v.(string))
 	}
@@ -693,14 +604,6 @@ func resourceAwsCognitoUserPoolRead(d *schema.ResourceData, meta interface{}) er
 		if err := d.Set("password_policy", flattenCognitoUserPoolPasswordPolicy(resp.UserPool.Policies.PasswordPolicy)); err != nil {
 			return fmt.Errorf("Failed setting password_policy: %s", err)
 		}
-	}
-
-	var configuredSchema []interface{}
-	if v, ok := d.GetOk("schema"); ok {
-		configuredSchema = v.(*schema.Set).List()
-	}
-	if err := d.Set("schema", flattenCognitoUserPoolSchema(expandCognitoUserPoolSchema(configuredSchema), resp.UserPool.SchemaAttributes)); err != nil {
-		return fmt.Errorf("Failed setting schema: %s", err)
 	}
 
 	if err := d.Set("sms_configuration", flattenCognitoUserPoolSmsConfiguration(resp.UserPool.SmsConfiguration)); err != nil {


### PR DESCRIPTION
# Why

Many of the Cognito user pool schema attributes are marked `ForceNew` and the array order of the items is non-deterministic across runs. This means user pools are frequently marked as "added" incorrectly. This is the user schema for cognito users which is not that important for us to understand so just removing this for now should be sufficient. We can add it back in later with adjustments if it becomes important.