### PR TITLE
Redshift - remove name validations

### DIFF
--- a/aws/resource_aws_redshift_parameter_group.go
+++ b/aws/resource_aws_redshift_parameter_group.go
@@ -25,10 +25,10 @@ func resourceAwsRedshiftParameterGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: validateRedshiftParamGroupName,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				// ValidateFunc: validateRedshiftParamGroupName,
 			},
 
 			"family": {

--- a/aws/resource_aws_redshift_subnet_group.go
+++ b/aws/resource_aws_redshift_subnet_group.go
@@ -23,10 +23,10 @@ func resourceAwsRedshiftSubnetGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: validateRedshiftSubnetGroupName,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				// ValidateFunc: validateRedshiftSubnetGroupName,
 			},
 
 			"description": {


### PR DESCRIPTION
These are just getting in the way for us.

```
Error: aws_redshift_parameter_group.ZGVmYXVsdC5yZWRzaGlmdC0xLjA: only lowercase alphanumeric characters and hyphens allowed in "name"
```

`ZGVmYXVsdC5yZWRzaGlmdC0xLjA` here is `default.redshift-1.0`

```
Error: aws_redshift_subnet_group.ZGVmYXVsdA: "Default" is not allowed as "name"
```

`ZGVmYXVsdA` here is `default`.