### PR TITLE
Remove unused_account_validity_days from Cognito User Pool type

### DIFF
--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -63,12 +63,12 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 								},
 							},
 						},
-						"unused_account_validity_days": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							Default:      7,
-							ValidateFunc: validation.IntBetween(0, 90),
-						},
+						// "unused_account_validity_days": {
+						// 	Type:         schema.TypeInt,
+						// 	Optional:     true,
+						// 	Default:      7,
+						// 	ValidateFunc: validation.IntBetween(0, 90),
+						// },
 					},
 				},
 			},

--- a/aws/structure.go
+++ b/aws/structure.go
@@ -2450,7 +2450,7 @@ func expandCognitoUserPoolAdminCreateUserConfig(config map[string]interface{}) *
 		}
 	}
 
-	configs.UnusedAccountValidityDays = aws.Int64(int64(config["unused_account_validity_days"].(int)))
+	// configs.UnusedAccountValidityDays = aws.Int64(int64(config["unused_account_validity_days"].(int)))
 
 	return configs
 }
@@ -2486,7 +2486,7 @@ func flattenCognitoUserPoolAdminCreateUserConfig(s *cognitoidentityprovider.Admi
 		}
 	}
 
-	config["unused_account_validity_days"] = *s.UnusedAccountValidityDays
+	// config["unused_account_validity_days"] = *s.UnusedAccountValidityDays
 
 	return []map[string]interface{}{config}
 }


### PR DESCRIPTION
AWS deprecated the "unused_account_validity_days" field.

The error seen when making an update:

```
[ERROR] Timing: Provider: [provider.aws.us-east-1] Type: [aws_cognito_user_pool] Start: [2019-09-07T19:57:14Z] End: [2019-09-07T19:57:15Z] Duration: [1.194s] Error [Error updating Cognito User pool: InvalidParameterException: Please use TemporaryPasswordValidityDays instead of UnusedAccountValidityDays
	status code: 400, request id: 54dbfdcc-9717-48e1-b16b-8644545284de]
```

See issues # 8827 and # 8845 in the main repo for discussion of this change and how to handle it. The issue is unresolved in the provider master branch still.

Rather than attempt to fix it in our fork we'll just drop support for this field for now. I've tested and confirmed this works fine for us.

