### PR TITLE
mark in/egress sg rules as non-computed

### DIFF
--- a/aws/resource_aws_security_group.go
+++ b/aws/resource_aws_security_group.go
@@ -72,7 +72,7 @@ func resourceAwsSecurityGroup() *schema.Resource {
 			"ingress": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {
@@ -135,7 +135,7 @@ func resourceAwsSecurityGroup() *schema.Resource {
 			"egress": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
+				Computed: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from_port": {


### PR DESCRIPTION
# What
mark in/egress rules on security groups as non-computed

# Why
For Fugue's automated use case we only ever interact with rules embedded inside of a security group. So it is completely valid to compare against a configuration of an empty rule set or a state of an empty rule state.

# Implications
If this provider is used outside of our use case it would be invalid and potentially dangerous to use the standalone ` aws_security_group_rule` type