### PR TITLE
Port ACM certificate fix

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -216,7 +216,7 @@ func convertValidationOptions(certificate *acm.CertificateDetail) ([]map[string]
 				for _, validationEmail := range o.ValidationEmails {
 					emailValidationResult = append(emailValidationResult, *validationEmail)
 				}
-			} else {
+			} else if o.ValidationStatus == nil || aws.StringValue(o.ValidationStatus) == acm.DomainStatusPendingValidation {
 				log.Printf("[DEBUG] No validation options need to retry: %#v", o)
 				return nil, nil, fmt.Errorf("No validation options need to retry: %#v", o)
 			}


### PR DESCRIPTION
From this commit:

https://github.com/terraform-providers/terraform-provider-aws/commit/64d73c1c96fecb74c37531d999ea17a833608c1f

https://github.com/KernelPanicAUS/terraform-provider-aws/pull/263/files

Issue this fixes:

```
No validation options need to retry: {
  DomainName: "<redacted>.it",
  ValidationDomain: "<redacted>.it",
  ValidationMethod: "EMAIL",
  ValidationStatus: "SUCCESS"
}
```