### PR TITLE
[RM-2550] update some global resources hard coded ids to match Fugue

### DIFF
--- a/aws/resource_aws_iam_account_password_policy.go
+++ b/aws/resource_aws_iam_account_password_policy.go
@@ -115,7 +115,9 @@ func resourceAwsIamAccountPasswordPolicyUpdate(d *schema.ResourceData, meta inte
 	}
 	log.Println("[DEBUG] IAM account password policy updated")
 
-	d.SetId("iam-account-password-policy")
+	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something
+	// more human readable
+	d.SetId("PasswordPolicy")
 
 	return resourceAwsIamAccountPasswordPolicyRead(d, meta)
 }

--- a/aws/resource_aws_iam_credential_report.go
+++ b/aws/resource_aws_iam_credential_report.go
@@ -86,7 +86,7 @@ func resourceAwsIamCredentialReport() *schema.Resource {
 }
 
 func resourceAwsIamCredentialReportUpdate(d *schema.ResourceData, meta interface{}) error {
-	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something
+	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something
 	// more human readable
 	d.SetId("CredentialReport")
 	return resourceAwsIamCredentialReportRead(d, meta)

--- a/aws/resource_aws_iam_credential_report.go
+++ b/aws/resource_aws_iam_credential_report.go
@@ -86,7 +86,9 @@ func resourceAwsIamCredentialReport() *schema.Resource {
 }
 
 func resourceAwsIamCredentialReportUpdate(d *schema.ResourceData, meta interface{}) error {
-	d.SetId("iam-credential-report")
+	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something	// RM-2550: (eric-luminal) Fugue sets the ID of this resource as something
+	// more human readable
+	d.SetId("CredentialReport")
 	return resourceAwsIamCredentialReportRead(d, meta)
 }
 


### PR DESCRIPTION
# What
Updates `aws_iam_account_password_policy` and `aws_iam_credential_report` to force the use of Id's generated by Fugue's import process

# Why
It is required that the ids match when Fugue is processing enforcement.