### PR TITLE
Suppress diff on certain resource attributes

### DIFF
--- a/aws/resource_aws_autoscaling_group.go
+++ b/aws/resource_aws_autoscaling_group.go
@@ -89,6 +89,9 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 
 			"min_elb_capacity": {

--- a/aws/resource_aws_dynamodb_table.go
+++ b/aws/resource_aws_dynamodb_table.go
@@ -86,10 +86,16 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			"write_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"read_capacity": {
 				Type:     schema.TypeInt,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"attribute": {
 				Type:     schema.TypeSet,
@@ -179,10 +185,16 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 						"write_capacity": {
 							Type:     schema.TypeInt,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 						"read_capacity": {
 							Type:     schema.TypeInt,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 						"hash_key": {
 							Type:     schema.TypeString,

--- a/aws/resource_aws_elb.go
+++ b/aws/resource_aws_elb.go
@@ -79,6 +79,9 @@ func resourceAwsElb() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				Set:      schema.HashString,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 
 			"security_groups": {

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -303,6 +303,11 @@ func resourceAwsInstance() *schema.Resource {
 
 			"tags": tagsSchema(),
 
+			"aws_tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+
 			"volume_tags": tagsSchemaComputed(),
 
 			"block_device": {
@@ -793,6 +798,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("tags", tagsToMap(instance.Tags))
+	d.Set("aws_tags", awsTagsToMap(instance.Tags))
 
 	if err := readVolumeTags(conn, d); err != nil {
 		return err
@@ -1968,4 +1974,14 @@ func getCreditSpecifications(conn *ec2.EC2, instanceId string) ([]map[string]int
 	}
 
 	return creditSpecifications, nil
+}
+
+func awsTagsToMap(ts []*ec2.Tag) map[string]string {
+	result := map[string]string{}
+	for _, t := range ts {
+		if tagIgnored(t) {
+			result[*t.Key] = *t.Value
+		}
+	}
+	return result
 }

--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -305,7 +305,11 @@ func resourceAwsInstance() *schema.Resource {
 
 			"aws_tags": {
 				Type:     schema.TypeMap,
+				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 
 			"volume_tags": tagsSchemaComputed(),
@@ -1979,7 +1983,7 @@ func getCreditSpecifications(conn *ec2.EC2, instanceId string) ([]map[string]int
 func awsTagsToMap(ts []*ec2.Tag) map[string]string {
 	result := map[string]string{}
 	for _, t := range ts {
-		if tagIgnored(t) {
+		if strings.HasPrefix(*t.Key, "aws:") {
 			result[*t.Key] = *t.Value
 		}
 	}


### PR DESCRIPTION
# Why

These fields commonly change during normal operation in AWS.

This also adds a new attribute `aws_tags` on `aws_instance` to capture AWS supplied tags that the provider previously ignored. This allows access to the ASG tag on instances. By using `DiffSuppressFunc` on this new attribute we ensure that when this appears there is not a diff.