### PR TITLE
[RM-2542] Backport updates to route53 zone

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -51,17 +51,39 @@ func resourceAwsRoute53Zone() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.NoZeroValues,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// Suppress diff when transitioning from the old schema
+								if d.Get("vpc_id").(string) == new {
+									return true
+								}
+								return false
+							},
 						},
 						"vpc_region": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// Suppress diff when transitioning from the old schema
+								if d.Get("vpc_region").(string) == new {
+									return true
+								}
+								return false
+							},
 						},
 					},
 				},
 				Set: route53HostedZoneVPCHash,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress vpc.# 0 -> vpc.# 1 when transitioning from the old schema
+					if d.Get("vpc_id").(string) != "" {
+						return true
+					}
+					return false
+				},
 			},
 
+			// Phasing this out since it's part of the old schema
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -73,6 +95,7 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				},
 			},
 
+			// Phasing this out since it's part of the old schema
 			"vpc_region": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -1,19 +1,19 @@
 package aws
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/errwrap"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsRoute53Zone() *schema.Resource {
@@ -40,18 +40,48 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Default:  "Managed by Terraform",
 			},
 
-			"vpc_id": {
-				Type:          schema.TypeString,
+			"vpc": {
+				Type:          schema.TypeSet,
 				Optional:      true,
-				ForceNew:      true,
+				MinItems:      1,
 				ConflictsWith: []string{"delegation_set_id"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vpc_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.NoZeroValues,
+						},
+						"vpc_region": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+				Set: route53HostedZoneVPCHash,
+			},
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// ForceNew: true,
+				Computed: true,
+				// Removed:  "use 'vpc' configuration block instead",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 
 			"vpc_region": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				// ForceNew: true,
 				Computed: true,
+				// Removed:  "use 'vpc' configuration block instead",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 
 			"zone_id": {
@@ -63,7 +93,7 @@ func resourceAwsRoute53Zone() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"vpc_id"},
+				ConflictsWith: []string{"vpc"},
 			},
 
 			"name_servers": {
@@ -84,141 +114,133 @@ func resourceAwsRoute53Zone() *schema.Resource {
 }
 
 func resourceAwsRoute53ZoneCreate(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
+	conn := meta.(*AWSClient).r53conn
+	region := meta.(*AWSClient).region
 
-	req := &route53.CreateHostedZoneInput{
-		Name:             aws.String(d.Get("name").(string)),
-		HostedZoneConfig: &route53.HostedZoneConfig{Comment: aws.String(d.Get("comment").(string))},
-		CallerReference:  aws.String(resource.UniqueId()),
-	}
-	if v := d.Get("vpc_id"); v != "" {
-		req.VPC = &route53.VPC{
-			VPCId:     aws.String(v.(string)),
-			VPCRegion: aws.String(meta.(*AWSClient).region),
-		}
-		if w := d.Get("vpc_region"); w != "" {
-			req.VPC.VPCRegion = aws.String(w.(string))
-		}
-		d.Set("vpc_region", req.VPC.VPCRegion)
+	input := &route53.CreateHostedZoneInput{
+		CallerReference: aws.String(resource.UniqueId()),
+		Name:            aws.String(d.Get("name").(string)),
+		HostedZoneConfig: &route53.HostedZoneConfig{
+			Comment: aws.String(d.Get("comment").(string)),
+		},
 	}
 
 	if v, ok := d.GetOk("delegation_set_id"); ok {
-		req.DelegationSetId = aws.String(v.(string))
+		input.DelegationSetId = aws.String(v.(string))
 	}
 
-	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", *req.Name)
-	var err error
-	resp, err := r53.CreateHostedZone(req)
+	// Private Route53 Hosted Zones can only be created with their first VPC association,
+	// however we need to associate the remaining after creation.
+
+	var vpcs []*route53.VPC = expandRoute53VPCs(d.Get("vpc").(*schema.Set).List(), region)
+
+	if len(vpcs) > 0 {
+		input.VPC = vpcs[0]
+	}
+
+	log.Printf("[DEBUG] Creating Route53 hosted zone: %s", input)
+	output, err := conn.CreateHostedZone(input)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating Route53 Hosted Zone: %s", err)
 	}
 
-	// Store the zone_id
-	zone := cleanZoneID(*resp.HostedZone.Id)
-	d.Set("zone_id", zone)
-	d.SetId(zone)
+	d.SetId(cleanZoneID(aws.StringValue(output.HostedZone.Id)))
 
-	// Wait until we are done initializing
-	wait := resource.StateChangeConf{
-		Delay:      30 * time.Second,
-		Pending:    []string{"PENDING"},
-		Target:     []string{"INSYNC"},
-		Timeout:    15 * time.Minute,
-		MinTimeout: 2 * time.Second,
-		Refresh: func() (result interface{}, state string, err error) {
-			changeRequest := &route53.GetChangeInput{
-				Id: aws.String(cleanChangeID(*resp.ChangeInfo.Id)),
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) creation: %s", d.Id(), err)
+	}
+
+	if err := setTagsR53(conn, d, route53.TagResourceTypeHostedzone); err != nil {
+		return fmt.Errorf("error setting tags for Route53 Hosted Zone (%s): %s", d.Id(), err)
+	}
+
+	// Associate additional VPCs beyond the first
+	if len(vpcs) > 1 {
+		for _, vpc := range vpcs[1:] {
+			err := route53HostedZoneVPCAssociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
 			}
-			return resourceAwsGoRoute53Wait(r53, changeRequest)
-		},
+		}
 	}
-	_, err = wait.WaitForState()
-	if err != nil {
-		return err
-	}
-	return resourceAwsRoute53ZoneUpdate(d, meta)
+
+	return resourceAwsRoute53ZoneRead(d, meta)
 }
 
 func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
-	zone, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(d.Id())})
+	conn := meta.(*AWSClient).r53conn
+
+	input := &route53.GetHostedZoneInput{
+		Id: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Getting Route53 Hosted Zone: %s", input)
+	output, err := conn.GetHostedZone(input)
+
+	if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+		log.Printf("[WARN] Route53 Hosted Zone (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
-		// Handle a deleted zone
-		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
-			d.SetId("")
-			return nil
-		}
-		return err
+		return fmt.Errorf("error getting Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
-	// In the import case this will be empty
-	if _, ok := d.GetOk("zone_id"); !ok {
-		d.Set("zone_id", d.Id())
-	}
-	if _, ok := d.GetOk("name"); !ok {
-		d.Set("name", zone.HostedZone.Name)
+	if output == nil || output.HostedZone == nil {
+		log.Printf("[WARN] Route53 Hosted Zone (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
-	if !*zone.HostedZone.Config.PrivateZone {
-		ns := make([]string, len(zone.DelegationSet.NameServers))
-		for i := range zone.DelegationSet.NameServers {
-			ns[i] = *zone.DelegationSet.NameServers[i]
-		}
-		sort.Strings(ns)
-		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
-		}
-	} else {
-		ns, err := getNameServers(d.Id(), d.Get("name").(string), r53)
-		if err != nil {
-			return err
-		}
-		if err := d.Set("name_servers", ns); err != nil {
-			return fmt.Errorf("[DEBUG] Error setting name servers for: %s, error: %#v", d.Id(), err)
-		}
+	d.Set("comment", "")
+	d.Set("delegation_set_id", "")
+	d.Set("name", output.HostedZone.Name)
+	d.Set("zone_id", cleanZoneID(aws.StringValue(output.HostedZone.Id)))
 
-		// In the import case we just associate it with the first VPC
-		if _, ok := d.GetOk("vpc_id"); !ok {
-			if len(zone.VPCs) > 1 {
-				return fmt.Errorf(
-					"Can't import a route53_zone with more than one VPC attachment")
-			}
+	var nameServers []string
 
-			if len(zone.VPCs) > 0 {
-				d.Set("vpc_id", zone.VPCs[0].VPCId)
-				d.Set("vpc_region", zone.VPCs[0].VPCRegion)
+	if output.DelegationSet != nil {
+		d.Set("delegation_set_id", cleanDelegationSetId(aws.StringValue(output.DelegationSet.Id)))
+
+		nameServers = aws.StringValueSlice(output.DelegationSet.NameServers)
+	}
+
+	if output.HostedZone.Config != nil {
+		d.Set("comment", output.HostedZone.Config.Comment)
+
+		if aws.BoolValue(output.HostedZone.Config.PrivateZone) {
+			var err error
+			nameServers, err = getNameServers(d.Id(), d.Get("name").(string), conn)
+
+			if err != nil {
+				return fmt.Errorf("error getting Route53 Hosted Zone (%s) name servers: %s", d.Id(), err)
 			}
 		}
-
-		var associatedVPC *route53.VPC
-		for _, vpc := range zone.VPCs {
-			if *vpc.VPCId == d.Get("vpc_id") {
-				associatedVPC = vpc
-				break
-			}
-		}
-		if associatedVPC == nil {
-			return fmt.Errorf("[DEBUG] VPC: %v is not associated with Zone: %v", d.Get("vpc_id"), d.Id())
-		}
 	}
 
-	if zone.DelegationSet != nil && zone.DelegationSet.Id != nil {
-		d.Set("delegation_set_id", cleanDelegationSetId(*zone.DelegationSet.Id))
+	sort.Strings(nameServers)
+	if err := d.Set("name_servers", nameServers); err != nil {
+		return fmt.Errorf("error setting name_servers: %s", err)
 	}
 
-	if zone.HostedZone != nil && zone.HostedZone.Config != nil && zone.HostedZone.Config.Comment != nil {
-		d.Set("comment", zone.HostedZone.Config.Comment)
+	if err := d.Set("vpc", flattenRoute53VPCs(output.VPCs)); err != nil {
+		return fmt.Errorf("error setting vpc: %s", err)
 	}
 
 	// get tags
 	req := &route53.ListTagsForResourceInput{
 		ResourceId:   aws.String(d.Id()),
-		ResourceType: aws.String("hostedzone"),
+		ResourceType: aws.String(route53.TagResourceTypeHostedzone),
 	}
 
-	resp, err := r53.ListTagsForResource(req)
+	log.Printf("[DEBUG] Listing tags for Route53 Hosted Zone: %s", req)
+	resp, err := conn.ListTagsForResource(req)
+
 	if err != nil {
-		return err
+		return fmt.Errorf("error listing tags for Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
 	var tags []*route53.Tag
@@ -235,27 +257,66 @@ func resourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).r53conn
+	region := meta.(*AWSClient).region
 
 	d.Partial(true)
 
 	if d.HasChange("comment") {
-		zoneInput := route53.UpdateHostedZoneCommentInput{
+		input := route53.UpdateHostedZoneCommentInput{
 			Id:      aws.String(d.Id()),
 			Comment: aws.String(d.Get("comment").(string)),
 		}
 
-		_, err := conn.UpdateHostedZoneComment(&zoneInput)
+		_, err := conn.UpdateHostedZoneComment(&input)
+
 		if err != nil {
-			return err
-		} else {
-			d.SetPartial("comment")
+			return fmt.Errorf("error updating Route53 Hosted Zone (%s) comment: %s", d.Id(), err)
 		}
+
+		d.SetPartial("comment")
 	}
 
-	if err := setTagsR53(conn, d, "hostedzone"); err != nil {
-		return err
-	} else {
+	if d.HasChange("tags") {
+		if err := setTagsR53(conn, d, route53.TagResourceTypeHostedzone); err != nil {
+			return err
+		}
+
 		d.SetPartial("tags")
+	}
+
+	if d.HasChange("vpc") {
+		o, n := d.GetChange("vpc")
+		oldVPCs := o.(*schema.Set)
+		newVPCs := n.(*schema.Set)
+
+		// VPCs cannot be empty, so add first and then remove
+		for _, vpcRaw := range newVPCs.Difference(oldVPCs).List() {
+			if vpcRaw == nil {
+				continue
+			}
+
+			vpc := expandRoute53VPC(vpcRaw.(map[string]interface{}), region)
+			err := route53HostedZoneVPCAssociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, vpcRaw := range oldVPCs.Difference(newVPCs).List() {
+			if vpcRaw == nil {
+				continue
+			}
+
+			vpc := expandRoute53VPC(vpcRaw.(map[string]interface{}), region)
+			err := route53HostedZoneVPCDisassociate(conn, d.Id(), vpc)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		d.SetPartial("vpc")
 	}
 
 	d.Partial(false)
@@ -264,22 +325,27 @@ func resourceAwsRoute53ZoneUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceAwsRoute53ZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	r53 := meta.(*AWSClient).r53conn
+	conn := meta.(*AWSClient).r53conn
 
 	if d.Get("force_destroy").(bool) {
-		if err := deleteAllRecordsInHostedZoneId(d.Id(), d.Get("name").(string), r53); err != nil {
-			return errwrap.Wrapf("{{err}}", err)
+		if err := deleteAllRecordsInHostedZoneId(d.Id(), d.Get("name").(string), conn); err != nil {
+			return fmt.Errorf("error deleting records in Route53 Hosted Zone (%s): %s", d.Id(), err)
 		}
 	}
 
-	log.Printf("[DEBUG] Deleting Route53 hosted zone: %s (ID: %s)",
-		d.Get("name").(string), d.Id())
-	_, err := r53.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: aws.String(d.Id())})
+	input := &route53.DeleteHostedZoneInput{
+		Id: aws.String(d.Id()),
+	}
+
+	log.Printf("[DEBUG] Deleting Route53 Hosted Zone: %s", input)
+	_, err := conn.DeleteHostedZone(input)
+
+	if isAWSErr(err, route53.ErrCodeNoSuchHostedZone, "") {
+		return nil
+	}
+
 	if err != nil {
-		if r53err, ok := err.(awserr.Error); ok && r53err.Code() == "NoSuchHostedZone" {
-			return nil
-		}
-		return err
+		return fmt.Errorf("error deleting Route53 Hosted Zone (%s): %s", d.Id(), err)
 	}
 
 	return nil
@@ -353,20 +419,12 @@ func resourceAwsGoRoute53Wait(r53 *route53.Route53, ref *route53.GetChangeInput)
 
 // cleanChangeID is used to remove the leading /change/
 func cleanChangeID(ID string) string {
-	return cleanPrefix(ID, "/change/")
+	return strings.TrimPrefix(ID, "/change/")
 }
 
 // cleanZoneID is used to remove the leading /hostedzone/
 func cleanZoneID(ID string) string {
-	return cleanPrefix(ID, "/hostedzone/")
-}
-
-// cleanPrefix removes a string prefix from an ID
-func cleanPrefix(ID, prefix string) string {
-	if strings.HasPrefix(ID, prefix) {
-		ID = strings.TrimPrefix(ID, prefix)
-	}
-	return ID
+	return strings.TrimPrefix(ID, "/hostedzone/")
 }
 
 func getNameServers(zoneId string, zoneName string, r53 *route53.Route53) ([]string, error) {
@@ -387,4 +445,130 @@ func getNameServers(zoneId string, zoneName string, r53 *route53.Route53) ([]str
 	}
 	sort.Strings(ns)
 	return ns, nil
+}
+
+func expandRoute53VPCs(l []interface{}, currentRegion string) []*route53.VPC {
+	vpcs := []*route53.VPC{}
+
+	for _, mRaw := range l {
+		if mRaw == nil {
+			continue
+		}
+
+		vpcs = append(vpcs, expandRoute53VPC(mRaw.(map[string]interface{}), currentRegion))
+	}
+
+	return vpcs
+}
+
+func expandRoute53VPC(m map[string]interface{}, currentRegion string) *route53.VPC {
+	vpc := &route53.VPC{
+		VPCId:     aws.String(m["vpc_id"].(string)),
+		VPCRegion: aws.String(currentRegion),
+	}
+
+	if v, ok := m["vpc_region"]; ok && v.(string) != "" {
+		vpc.VPCRegion = aws.String(v.(string))
+	}
+
+	return vpc
+}
+
+func flattenRoute53VPCs(vpcs []*route53.VPC) []interface{} {
+	l := []interface{}{}
+
+	for _, vpc := range vpcs {
+		if vpc == nil {
+			continue
+		}
+
+		m := map[string]interface{}{
+			"vpc_id":     aws.StringValue(vpc.VPCId),
+			"vpc_region": aws.StringValue(vpc.VPCRegion),
+		}
+
+		l = append(l, m)
+	}
+
+	return l
+}
+
+func route53HostedZoneVPCAssociate(conn *route53.Route53, zoneID string, vpc *route53.VPC) error {
+	input := &route53.AssociateVPCWithHostedZoneInput{
+		HostedZoneId: aws.String(zoneID),
+		VPC:          vpc,
+	}
+
+	log.Printf("[DEBUG] Associating Route53 Hosted Zone with VPC: %s", input)
+	output, err := conn.AssociateVPCWithHostedZone(input)
+
+	if err != nil {
+		return fmt.Errorf("error associating Route53 Hosted Zone (%s) to VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) association to VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	return nil
+}
+
+func route53HostedZoneVPCDisassociate(conn *route53.Route53, zoneID string, vpc *route53.VPC) error {
+	input := &route53.DisassociateVPCFromHostedZoneInput{
+		HostedZoneId: aws.String(zoneID),
+		VPC:          vpc,
+	}
+
+	log.Printf("[DEBUG] Disassociating Route53 Hosted Zone with VPC: %s", input)
+	output, err := conn.DisassociateVPCFromHostedZone(input)
+
+	if err != nil {
+		return fmt.Errorf("error disassociating Route53 Hosted Zone (%s) from VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	if err := route53WaitForChangeSynchronization(conn, cleanChangeID(aws.StringValue(output.ChangeInfo.Id))); err != nil {
+		return fmt.Errorf("error waiting for Route53 Hosted Zone (%s) disassociation from VPC (%s): %s", zoneID, aws.StringValue(vpc.VPCId), err)
+	}
+
+	return nil
+}
+
+func route53HostedZoneVPCHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["vpc_id"].(string)))
+
+	return hashcode.String(buf.String())
+}
+
+func route53WaitForChangeSynchronization(conn *route53.Route53, changeID string) error {
+	conf := resource.StateChangeConf{
+		Delay:      30 * time.Second,
+		Pending:    []string{route53.ChangeStatusPending},
+		Target:     []string{route53.ChangeStatusInsync},
+		Timeout:    15 * time.Minute,
+		MinTimeout: 2 * time.Second,
+		Refresh: func() (result interface{}, state string, err error) {
+			input := &route53.GetChangeInput{
+				Id: aws.String(changeID),
+			}
+
+			log.Printf("[DEBUG] Getting Route53 Change status: %s", input)
+			output, err := conn.GetChange(input)
+
+			if err != nil {
+				return nil, "UNKNOWN", err
+			}
+
+			if output == nil || output.ChangeInfo == nil {
+				return nil, "UNKNOWN", fmt.Errorf("Route53 GetChange response empty for ID: %s", changeID)
+			}
+
+			return true, aws.StringValue(output.ChangeInfo.Status), nil
+		},
+	}
+
+	_, err := conf.WaitForState()
+
+	return err
 }

--- a/aws/resource_aws_route53_zone_test.go
+++ b/aws/resource_aws_route53_zone_test.go
@@ -14,23 +14,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestCleanPrefix(t *testing.T) {
-	cases := []struct {
-		Input, Prefix, Output string
-	}{
-		{"/hostedzone/foo", "/hostedzone/", "foo"},
-		{"/change/foo", "/change/", "foo"},
-		{"/bar", "/test", "/bar"},
-	}
-
-	for _, tc := range cases {
-		actual := cleanPrefix(tc.Input, tc.Prefix)
-		if actual != tc.Output {
-			t.Fatalf("input: %s\noutput: %s", tc.Input, actual)
-		}
-	}
-}
-
 func TestCleanZoneID(t *testing.T) {
 	cases := []struct {
 		Input, Output string
@@ -66,38 +49,81 @@ func TestCleanChangeID(t *testing.T) {
 }
 
 func TestAccAWSRoute53Zone_basic(t *testing.T) {
-	var zone, zone0, zone1, zone2, zone3, zone4 route53.GetHostedZoneOutput
-	var td route53.ResourceTagSet
+	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
 	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoute53ZoneConfig(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
-					testAccLoadTagsR53(&zone, &td),
-					testAccCheckTagsR53(&td.Tags, "foo", "bar"),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s.", zoneName)),
+					resource.TestCheckResourceAttr(resourceName, "name_servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "0"),
 				),
 			},
 			{
-				Config: testAccRoute53ZoneCountConfig(),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_disappears(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfig(zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.0", &zone0),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					testAccCheckRoute53ZoneDisappears(&zone),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_multiple(t *testing.T) {
+	var zone0, zone1, zone2, zone3, zone4 route53.GetHostedZoneOutput
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigMultiple(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.0", &zone0),
 					testAccCheckDomainName(&zone0, "subdomain0.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.1", &zone1),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.1", &zone1),
 					testAccCheckDomainName(&zone1, "subdomain1.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.2", &zone2),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.2", &zone2),
 					testAccCheckDomainName(&zone2, "subdomain2.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.3", &zone3),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.3", &zone3),
 					testAccCheckDomainName(&zone3, "subdomain3.terraformtest.com."),
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main.4", &zone4),
+					testAccCheckRoute53ZoneExists("aws_route53_zone.test.4", &zone4),
 					testAccCheckDomainName(&zone4, "subdomain4.terraformtest.com."),
 				),
 			},
@@ -105,129 +131,278 @@ func TestAccAWSRoute53Zone_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSRoute53Zone_forceDestroy(t *testing.T) {
-	var zone, zoneWithDot route53.GetHostedZoneOutput
+func TestAccAWSRoute53Zone_Comment(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
 
 	rString := acctest.RandString(8)
-	zoneName1 := fmt.Sprintf("%s-one.terraformtest.com", rString)
-	zoneName2 := fmt.Sprintf("%s-two.terraformtest.com", rString)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
 
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "aws_route53_zone.destroyable",
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneDestroyWithProvider, &providers),
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneConfig_forceDestroy(zoneName1, zoneName2),
+				Config: testAccRoute53ZoneConfigComment(zoneName, "comment1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.destroyable", &zone,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					// Add >100 records to verify pagination works ok
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zone, 100),
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zone, 5),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "comment", "comment1"),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigComment(zoneName, "comment2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "comment", "comment2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
 
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.with_trailing_dot", &zoneWithDot,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
+func TestAccAWSRoute53Zone_DelegationSetID(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	delegationSetResourceName := "aws_route53_delegation_set.test"
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigDelegationSetID(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttrPair(resourceName, "delegation_set_id", delegationSetResourceName, "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_ForceDestroy(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigForceDestroy(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
 					// Add >100 records to verify pagination works ok
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zoneWithDot, 100),
-					testAccCreateRandomRoute53RecordsInZoneIdWithProvider(
-						testAccAwsRegionProviderFunc("us-west-2", &providers), &zoneWithDot, 5),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 100),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 5),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_updateComment(t *testing.T) {
+func TestAccAWSRoute53Zone_ForceDestroy_TrailingPeriod(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rString := acctest.RandString(8)
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigForceDestroyTrailingPeriod(zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					// Add >100 records to verify pagination works ok
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 100),
+					testAccCreateRandomRoute53RecordsInZoneId(&zone, 5),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_Tags(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 	var td route53.ResourceTagSet
 
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53ZoneConfig(zoneName),
+				Config: testAccRoute53ZoneConfigTagsSingle(zoneName, "tag1key", "tag1value"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1key", "tag1value"),
 					testAccLoadTagsR53(&zone, &td),
-					testAccCheckTagsR53(&td.Tags, "foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"aws_route53_zone.main", "comment", "Custom comment"),
+					testAccCheckTagsR53(&td.Tags, "tag1key", "tag1value"),
 				),
 			},
-
 			{
-				Config: testAccRoute53ZoneConfigUpdateComment(zoneName),
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccRoute53ZoneConfigTagsMultiple(zoneName, "tag1key", "tag1valueupdated", "tag2key", "tag2value"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag1key", "tag1valueupdated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2key", "tag2value"),
 					testAccLoadTagsR53(&zone, &td),
-					resource.TestCheckResourceAttr(
-						"aws_route53_zone.main", "comment", "Change Custom Comment"),
+					testAccCheckTagsR53(&td.Tags, "tag1key", "tag1valueupdated"),
+					testAccCheckTagsR53(&td.Tags, "tag2key", "tag2value"),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigTagsSingle(zoneName, "tag2key", "tag2value"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.tag2key", "tag2value"),
+					testAccLoadTagsR53(&zone, &td),
+					testAccCheckTagsR53(&td.Tags, "tag2key", "tag2value"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_private_basic(t *testing.T) {
+func TestAccAWSRoute53Zone_VPC_Single(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName := "aws_vpc.test1"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:      func() { testAccPreCheck(t) },
-		IDRefreshName: "aws_route53_zone.main",
-		Providers:     testAccProviders,
-		CheckDestroy:  testAccCheckRoute53ZoneDestroy,
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53PrivateZoneConfig(zoneName),
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExists("aws_route53_zone.main", &zone),
-					testAccCheckRoute53ZoneAssociatesWithVpc("aws_vpc.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName, &zone),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
 }
 
-func TestAccAWSRoute53Zone_private_region(t *testing.T) {
+func TestAccAWSRoute53Zone_VPC_Multiple(t *testing.T) {
 	var zone route53.GetHostedZoneOutput
 
-	rString := acctest.RandString(8)
-	zoneName := fmt.Sprintf("%s.terraformtest.com", rString)
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName1 := "aws_vpc.test1"
+	vpcResourceName2 := "aws_vpc.test2"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
 
-	// record the initialized providers so that we can use them to
-	// check for the instances in each region
-	var providers []*schema.Provider
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		IDRefreshName:     "aws_route53_zone.main",
-		ProviderFactories: testAccProviderFactories(&providers),
-		CheckDestroy:      testAccCheckWithProviders(testAccCheckRoute53ZoneDestroyWithProvider, &providers),
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRoute53PrivateZoneRegionConfig(zoneName),
+				Config: testAccRoute53ZoneConfigVPCMultiple(rName, zoneName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRoute53ZoneExistsWithProvider("aws_route53_zone.main", &zone,
-						testAccAwsRegionProviderFunc("us-west-2", &providers)),
-					testAccCheckRoute53ZoneAssociatesWithVpc("aws_vpc.main", &zone),
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "2"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName2, &zone),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccAWSRoute53Zone_VPC_Updates(t *testing.T) {
+	var zone route53.GetHostedZoneOutput
+
+	rName := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "aws_route53_zone.test"
+	vpcResourceName1 := "aws_vpc.test1"
+	vpcResourceName2 := "aws_vpc.test2"
+	zoneName := fmt.Sprintf("%s.terraformtest.com", rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigVPCMultiple(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "2"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName2, &zone),
+				),
+			},
+			{
+				Config: testAccRoute53ZoneConfigVPCSingle(rName, zoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoute53ZoneExists(resourceName, &zone),
+					resource.TestCheckResourceAttr(resourceName, "vpc.#", "1"),
+					testAccCheckRoute53ZoneAssociatesWithVpc(vpcResourceName1, &zone),
 				),
 			},
 		},
@@ -251,6 +426,10 @@ func testAccCheckRoute53ZoneDestroyWithProvider(s *terraform.State, provider *sc
 		}
 	}
 	return nil
+}
+
+func testAccCreateRandomRoute53RecordsInZoneId(zone *route53.GetHostedZoneOutput, recordsCount int) resource.TestCheckFunc {
+	return testAccCreateRandomRoute53RecordsInZoneIdWithProvider(func() *schema.Provider { return testAccProvider }, zone, recordsCount)
 }
 
 func testAccCreateRandomRoute53RecordsInZoneIdWithProvider(providerF func() *schema.Provider, zone *route53.GetHostedZoneOutput, recordsCount int) resource.TestCheckFunc {
@@ -342,6 +521,20 @@ func testAccCheckRoute53ZoneExistsWithProvider(n string, zone *route53.GetHosted
 	}
 }
 
+func testAccCheckRoute53ZoneDisappears(zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).r53conn
+
+		input := &route53.DeleteHostedZoneInput{
+			Id: zone.HostedZone.Id,
+		}
+
+		_, err := conn.DeleteHostedZone(input)
+
+		return err
+	}
+}
+
 func testAccCheckRoute53ZoneAssociatesWithVpc(n string, zone *route53.GetHostedZoneOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -353,16 +546,13 @@ func testAccCheckRoute53ZoneAssociatesWithVpc(n string, zone *route53.GetHostedZ
 			return fmt.Errorf("No VPC ID is set")
 		}
 
-		var associatedVPC *route53.VPC
 		for _, vpc := range zone.VPCs {
-			if *vpc.VPCId == rs.Primary.ID {
-				associatedVPC = vpc
+			if aws.StringValue(vpc.VPCId) == rs.Primary.ID {
+				return nil
 			}
 		}
-		if associatedVPC == nil {
-			return fmt.Errorf("VPC: %v is not associated to Zone: %v", n, cleanZoneID(*zone.HostedZone.Id))
-		}
-		return nil
+
+		return fmt.Errorf("VPC: %s is not associated to Zone: %v", n, cleanZoneID(aws.StringValue(zone.HostedZone.Id)))
 	}
 }
 
@@ -403,103 +593,133 @@ func testAccCheckDomainName(zone *route53.GetHostedZoneOutput, domain string) re
 }
 func testAccRoute53ZoneConfig(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	comment = "Custom comment"
-
-	tags {
-		foo = "bar"
-		Name = "tf-route53-tag-test"
-	}
+resource "aws_route53_zone" "test" {
+  name = "%s."
 }
 `, zoneName)
 }
 
-func testAccRoute53ZoneCountConfig() string {
+func testAccRoute53ZoneConfigMultiple() string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "subdomain${count.index}.terraformtest.com"
+resource "aws_route53_zone" "test" {
+  count = 5
 
-	count = 5
+  name = "subdomain${count.index}.terraformtest.com"
 }
 `)
 }
 
-func testAccRoute53ZoneConfig_forceDestroy(zoneName1, zoneName2 string) string {
+func testAccRoute53ZoneConfigComment(zoneName, comment string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "destroyable" {
-	name = "%s"
-	force_destroy = true
+resource "aws_route53_zone" "test" {
+  comment = %q
+  name    = "%s."
+}
+`, comment, zoneName)
 }
 
-resource "aws_route53_zone" "with_trailing_dot" {
-	name = "%s."
-	force_destroy = true
-}
-`, zoneName1, zoneName2)
-}
-
-func testAccRoute53ZoneConfigUpdateComment(zoneName string) string {
+func testAccRoute53ZoneConfigDelegationSetID(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	comment = "Change Custom Comment"
+resource "aws_route53_delegation_set" "test" {}
 
-	tags {
-		foo = "bar"
-		Name = "tf-route53-tag-test"
-	}
+resource "aws_route53_zone" "test" {
+  delegation_set_id = "${aws_route53_delegation_set.test.id}"
+  name              = "%s."
 }
 `, zoneName)
 }
 
-func testAccRoute53PrivateZoneConfig(zoneName string) string {
+func testAccRoute53ZoneConfigForceDestroy(zoneName string) string {
 	return fmt.Sprintf(`
-resource "aws_vpc" "main" {
-	cidr_block = "172.29.0.0/24"
-	instance_tenancy = "default"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-route53-zone-private"
-	}
-}
-
-resource "aws_route53_zone" "main" {
-	name = "%s."
-	vpc_id = "${aws_vpc.main.id}"
+resource "aws_route53_zone" "test" {
+  force_destroy = true
+  name          = "%s"
 }
 `, zoneName)
 }
 
-func testAccRoute53PrivateZoneRegionConfig(zoneName string) string {
+func testAccRoute53ZoneConfigForceDestroyTrailingPeriod(zoneName string) string {
 	return fmt.Sprintf(`
-provider "aws" {
-	alias = "west"
-	region = "us-west-2"
-}
-
-provider "aws" {
-	alias = "east"
-	region = "us-east-1"
-}
-
-resource "aws_vpc" "main" {
-	provider = "aws.east"
-	cidr_block = "172.29.0.0/24"
-	instance_tenancy = "default"
-	enable_dns_support = true
-	enable_dns_hostnames = true
-	tags {
-		Name = "terraform-testacc-route53-zone-private-region"
-	}
-}
-
-resource "aws_route53_zone" "main" {
-	provider = "aws.west"
-	name = "%s."
-	vpc_id = "${aws_vpc.main.id}"
-	vpc_region = "us-east-1"
+resource "aws_route53_zone" "test" {
+  force_destroy = true
+  name          = "%s."
 }
 `, zoneName)
+}
+
+func testAccRoute53ZoneConfigTagsSingle(zoneName, tag1Key, tag1Value string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  tags = {
+    %q = %q
+  }
+}
+`, zoneName, tag1Key, tag1Value)
+}
+
+func testAccRoute53ZoneConfigTagsMultiple(zoneName, tag1Key, tag1Value, tag2Key, tag2Value string) string {
+	return fmt.Sprintf(`
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  tags = {
+    %q = %q
+    %q = %q
+  }
+}
+`, zoneName, tag1Key, tag1Value, tag2Key, tag2Value)
+}
+
+func testAccRoute53ZoneConfigVPCSingle(rName, zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  vpc {
+    vpc_id = "${aws_vpc.test1.id}"
+  }
+}
+`, rName, zoneName)
+}
+
+func testAccRoute53ZoneConfigVPCMultiple(rName, zoneName string) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test1" {
+  cidr_block = "10.1.0.0/16"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_vpc" "test2" {
+  cidr_block = "10.2.0.0/16"
+
+  tags = {
+    Name = %q
+  }
+}
+
+resource "aws_route53_zone" "test" {
+  name = "%s."
+
+  vpc {
+    vpc_id = "${aws_vpc.test1.id}"
+  }
+
+  vpc {
+    vpc_id = "${aws_vpc.test2.id}"
+  }
+}
+`, rName, rName, zoneName)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apparentlymart/go-cidr v0.0.0-20170418151526-7e4b007599d4 // indirect
 	github.com/apparentlymart/go-textseg v0.0.0-20170531203952-b836f5c4d331 // indirect
 	github.com/armon/go-radix v0.0.0-20170727155443-1fca145dffbc // indirect
-	github.com/aws/aws-sdk-go v1.15.75
+	github.com/aws/aws-sdk-go v1.25.12
 	github.com/beevik/etree v0.0.0-20171015221209-af219c0c7ea1
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -31,7 +31,6 @@ require (
 	github.com/hashicorp/vault v0.0.0-20161029210149-9a60bf2a50e4
 	github.com/hashicorp/yamux v0.0.0-20160720233140-d1caa6c97c9f // indirect
 	github.com/jen20/awspolicyequivalence v0.0.0-20180316120552-9fbcaca9f9f8
-	github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 // indirect
 	github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/armon/go-radix v0.0.0-20170727155443-1fca145dffbc h1:/WQ8Tr5zbclKWAtv
 github.com/armon/go-radix v0.0.0-20170727155443-1fca145dffbc/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.15.75 h1:KV0OmIfKLyAypOXjZMulzqmoHHGX8J0+3wJJVJNX2hs=
 github.com/aws/aws-sdk-go v1.15.75/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
+github.com/aws/aws-sdk-go v1.25.12 h1:a4h2FxoUJq9h+hajSE/dsRiqoOniIh6BkzhxMjkepzY=
+github.com/aws/aws-sdk-go v1.25.12/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beevik/etree v0.0.0-20171015221209-af219c0c7ea1 h1:6fqkBkx5cRbd8Pq0UEMxyteIAPoE1KiPptnx1yEzJLU=
 github.com/beevik/etree v0.0.0-20171015221209-af219c0c7ea1/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
@@ -61,6 +63,8 @@ github.com/jen20/awspolicyequivalence v0.0.0-20180316120552-9fbcaca9f9f8/go.mod 
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 h1:SMvOWPJCES2GdFracYbBQh93GXac8fq7HeN6JnpduB8=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba h1:NARVGAAgEXvoMeNPHhPFt1SBt1VMznA3Gnz9d0qj+co=
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
This updates the route53 zone type to what is found in v2.31.0 from upstream.

See PR 6299 specifically.

Tested and verified already.