### PR TITLE
RM-2704 Remove default value from route53 zone comment

### DIFF
--- a/aws/resource_aws_route53_zone.go
+++ b/aws/resource_aws_route53_zone.go
@@ -37,7 +37,6 @@ func resourceAwsRoute53Zone() *schema.Resource {
 			"comment": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Managed by Terraform",
 			},
 
 			"vpc": {


### PR DESCRIPTION
# WHY
The default value was causing spurious drift events