### PR TITLE
RM-2739 Add a DiffSuppressFunc to environment in aws_lambda_function

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -193,7 +193,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 					},
 				},
 				DiffSuppressFunc: func(k, old, neww string, d *schema.ResourceData) bool {
-					ioutil.WriteFile("awslog", []byte(fmt.Sprintf("%v %v %v", k, old, neww)), 0644)
 					if old == "1" && neww == "0" {
 						_, ok := d.GetOk("environment.0.variables.%")
 						if !ok {

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -192,6 +192,16 @@ func resourceAwsLambdaFunction() *schema.Resource {
 						},
 					},
 				},
+				DiffSuppressFunc: func(k, old, neww string, d *schema.ResourceData) bool {
+					ioutil.WriteFile("awslog", []byte(fmt.Sprintf("%v %v %v", k, old, neww)), 0644)
+					if old == "1" && neww == "0" {
+						_, ok := d.GetOk("environment.0.variables.%")
+						if !ok {
+							return true
+						}
+					}
+					return old == neww
+				},
 			},
 			"tracing_config": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
# WHY
A customer was seeing spurious drift that showed `environment.#` with an incorrect value. 

# WHAT
I was unable to find the root cause of the incorrect value, so I added a `DiffSuppressFunc` to the field which ignores the specific case the customer was seeing. Other cases are left alone so drift detection should still work in those cases.

# NOTE
Tested locally using `terraform plan`:
* tfstate with `environment.# = 1` and config with no environment block does not generate drift
* tfstate with `environment.# = 1` and config with environment block generates drift to set the environment variables in the block
* tfstate with `environment.# = 0` and config with no environment block does not generate drift
* tfstate with `environment.# = 0` and config with environment block generates drift to set the environment variables in the block
* Customer's tfstate and config does not generate drift, where it did before

https://luminal.atlassian.net/browse/RM-2739