### PR TITLE
[RM-2991] Increase config rule name length to 128

### DIFF
--- a/aws/resource_aws_config_config_rule.go
+++ b/aws/resource_aws_config_config_rule.go
@@ -31,7 +31,10 @@ func resourceAwsConfigConfigRule() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validateMaxLength(64),
+				ValidateFunc: validateMaxLength(128),
+				// The API documentation claims the maximum name length is 64,
+				// but when you use the AWS console, it shows a maximum length
+				// of 128 and allows you to create such rules with a long name.
 			},
 			"rule_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The API documentation claims the maximum name length is 64, but when you
use the AWS console, it shows a maximum length of 128 and allows you to
create such rules with a long name.