### PR TITLE
[RM-3026] Add postgresql to Cloudwatch Log Export Types

### DIFF
--- a/aws/resource_aws_rds_cluster.go
+++ b/aws/resource_aws_rds_cluster.go
@@ -376,6 +376,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 						"error",
 						"general",
 						"slowquery",
+						"postgresql",
 					}, false),
 				},
 			},


### PR DESCRIPTION
## What

Adds `postgresql`to the types allowed for `enabled_cloudwatch_logs_exports` attribute in rds clusters.

## JIRA
https://luminal.atlassian.net/browse/RM-3026
