### PR TITLE
[RM-3123] Remove ConflictsWith for launch template security groups

### DIFF
--- a/aws/resource_aws_launch_template.go
+++ b/aws/resource_aws_launch_template.go
@@ -379,17 +379,17 @@ func resourceAwsLaunchTemplate() *schema.Resource {
 			},
 
 			"security_group_names": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"vpc_security_group_ids"},
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				// ConflictsWith: []string{"vpc_security_group_ids"},  // See: RM-3123
 			},
 
 			"vpc_security_group_ids": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"security_group_names"},
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				// ConflictsWith: []string{"security_group_names"},  // See: RM-3123
 			},
 
 			"tag_specifications": {
@@ -861,6 +861,7 @@ func buildLaunchTemplateData(d *schema.ResourceData, meta interface{}) (*ec2.Req
 	}
 
 	if v, ok := d.GetOk("vpc_security_group_ids"); ok {
+		opts.SecurityGroups = nil  // See: RM-3123
 		opts.SecurityGroupIds = expandStringList(v.(*schema.Set).List())
 	}
 


### PR DESCRIPTION
It should not be possible to set both `security_group_names` and
`vpc_security_group_ids` at the same time, but someone managed to do it anyway.

It is important to note that the contents of the two fields is the same;
except the `security_group_names` is a bit bogus so I suspect there is some
AWS bug that happened during validation and allowed this to be set.

This means that in cases where both are set; we can assume they are set
to the same value and for drift we only want to set one of them; which is
`vpc_security_group_ids`, since `security_group_names` seems deprecated in
favor of that.