### PR TITLE
Scan V2 Fixes

### DIFF
--- a/aws/resource_aws_autoscaling_policy.go
+++ b/aws/resource_aws_autoscaling_policy.go
@@ -77,14 +77,14 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 				Removed:  "Use `min_adjustment_magnitude` argument instead",
 			},
 			"scaling_adjustment": {
-				Type:          schema.TypeInt,
-				Optional:      true,
-				ConflictsWith: []string{"step_adjustment"},
+				Type:     schema.TypeInt,
+				Optional: true,
+				// ConflictsWith: []string{"step_adjustment"},
 			},
 			"step_adjustment": {
-				Type:          schema.TypeSet,
-				Optional:      true,
-				ConflictsWith: []string{"scaling_adjustment"},
+				Type:     schema.TypeSet,
+				Optional: true,
+				// ConflictsWith: []string{"scaling_adjustment"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"metric_interval_lower_bound": {
@@ -110,10 +110,10 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"predefined_metric_specification": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification"},
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							// ConflictsWith: []string{"target_tracking_configuration.0.customized_metric_specification"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"predefined_metric_type": {
@@ -128,10 +128,10 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 							},
 						},
 						"customized_metric_specification": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							MaxItems:      1,
-							ConflictsWith: []string{"target_tracking_configuration.0.predefined_metric_specification"},
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							// ConflictsWith: []string{"target_tracking_configuration.0.predefined_metric_specification"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"metric_dimension": {

--- a/aws/resource_aws_cognito_user_pool.go
+++ b/aws/resource_aws_cognito_user_pool.go
@@ -164,19 +164,19 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			},
 
 			"email_verification_subject": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ValidateFunc:  validateCognitoUserPoolEmailVerificationSubject,
-				ConflictsWith: []string{"verification_message_template.0.email_subject"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateCognitoUserPoolEmailVerificationSubject,
+				// ConflictsWith: []string{"verification_message_template.0.email_subject"},
 			},
 
 			"email_verification_message": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ValidateFunc:  validateCognitoUserPoolEmailVerificationMessage,
-				ConflictsWith: []string{"verification_message_template.0.email_message"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateCognitoUserPoolEmailVerificationMessage,
+				// ConflictsWith: []string{"verification_message_template.0.email_message"},
 			},
 
 			"endpoint": {
@@ -331,11 +331,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 			},
 
 			"sms_verification_message": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ValidateFunc:  validateCognitoUserPoolSmsVerificationMessage,
-				ConflictsWith: []string{"verification_message_template.0.sms_message"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateCognitoUserPoolSmsVerificationMessage,
+				// ConflictsWith: []string{"verification_message_template.0.sms_message"},
 			},
 
 			"tags": tagsSchema(),
@@ -351,7 +351,7 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 						cognitoidentityprovider.UsernameAttributeTypePhoneNumber,
 					}, false),
 				},
-				ConflictsWith: []string{"alias_attributes"},
+				// ConflictsWith: []string{"alias_attributes"},
 			},
 
 			"user_pool_add_ons": {
@@ -390,11 +390,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							}, false),
 						},
 						"email_message": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ValidateFunc:  validateCognitoUserPoolTemplateEmailMessage,
-							ConflictsWith: []string{"email_verification_message"},
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateCognitoUserPoolTemplateEmailMessage,
+							// ConflictsWith: []string{"email_verification_message"},
 						},
 						"email_message_by_link": {
 							Type:         schema.TypeString,
@@ -403,11 +403,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							ValidateFunc: validateCognitoUserPoolTemplateEmailMessageByLink,
 						},
 						"email_subject": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ValidateFunc:  validateCognitoUserPoolTemplateEmailSubject,
-							ConflictsWith: []string{"email_verification_subject"},
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateCognitoUserPoolTemplateEmailSubject,
+							// ConflictsWith: []string{"email_verification_subject"},
 						},
 						"email_subject_by_link": {
 							Type:         schema.TypeString,
@@ -416,11 +416,11 @@ func resourceAwsCognitoUserPool() *schema.Resource {
 							ValidateFunc: validateCognitoUserPoolTemplateEmailSubjectByLink,
 						},
 						"sms_message": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Computed:      true,
-							ValidateFunc:  validateCognitoUserPoolTemplateSmsMessage,
-							ConflictsWith: []string{"sms_verification_message"},
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validateCognitoUserPoolTemplateSmsMessage,
+							// ConflictsWith: []string{"sms_verification_message"},
 						},
 					},
 				},

--- a/aws/resource_aws_kms_key.go
+++ b/aws/resource_aws_kms_key.go
@@ -50,6 +50,7 @@ func resourceAwsKmsKey() *schema.Resource {
 					kms.KeyUsageTypeEncryptDecrypt,
 					kms.KeyUsageTypeSignVerify,
 				}, false),
+				DiffSuppressFunc: suppressEmptyToDefault(kms.KeyUsageTypeEncryptDecrypt),
 			},
 			"customer_master_key_spec": {
 				Type:     schema.TypeString,

--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -30,6 +30,7 @@ var validLambdaRuntimes = []string{
 	lambda.RuntimeGo1X,
 	lambda.RuntimeJava8,
 	lambda.RuntimeJava11,
+	lambda.RuntimeNodejs,
 	lambda.RuntimeNodejs43,
 	lambda.RuntimeNodejs43Edge,
 	lambda.RuntimeNodejs610,

--- a/aws/resource_aws_route53_health_check.go
+++ b/aws/resource_aws_route53_health_check.go
@@ -48,10 +48,10 @@ func resourceAwsRoute53HealthCheck() *schema.Resource {
 				Optional: true,
 			},
 			"request_interval": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ForceNew:     true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
-				ValidateFunc: validation.IntInSlice([]int{10, 30}),
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true, // todo this should be updateable but the awslabs route53 service doesnt have the ability
+				// ValidateFunc: validation.IntInSlice([]int{10, 30}),
 			},
 			"ip_address": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
* aws_autoscaling_policy: remove conflicts
* aws_cognito_user_pool: remove conflicts
* aws_kms_key: suppress diff for new default value
* aws_lambda_function: add old `nodejs` value back to enum
* aws_organizations_organization: remove calls that require additional permissions
* aws_route53_health_check: remove validation