### PR TITLE
[RM 3358] docker cis health status

### DIFF
--- a/aws/resource_aws_ecs_task.go
+++ b/aws/resource_aws_ecs_task.go
@@ -112,6 +112,11 @@ func resourceAwsEcsTask() *schema.Resource {
 					},
 				},
 			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -138,6 +143,7 @@ func resourceAwsEcsTaskRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("task_definition_arn", task.TaskDefinitionArn)
 	d.Set("group", task.Group)
 	d.Set("launch_type", task.LaunchType)
+	d.Set("health_status", task.HealthStatus)
 
 	if err := d.Set("containers", flattenEcsTaskContainers(task.Containers)); err != nil {
 		return err


### PR DESCRIPTION
## Description

Adds healthStatus to the ECS task resource to support Docker CIS 5.26 - Ensure task health is monitored.

## Fugue PR

https://github.com/LuminalHQ/risk-manager/pull/2248

## Jira

https://luminal.atlassian.net/browse/RM-3358