### PR TITLE
[RM-3607] Remove ValidateFunc from stickiness.type, v1

### DIFF
--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -132,9 +132,6 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"lb_cookie",
-							}, false),
 						},
 						"cookie_duration": {
 							Type:         schema.TypeInt,


### PR DESCRIPTION
Removes ValidateFunc for stickiness.type to allow `ip_source` value in drift