### PR TITLE
[RM-3647] apigateway domain name update

### DIFF
--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -65,7 +65,7 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 			"certificate_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"certificate_body", "certificate_chain", "certificate_name", "certificate_private_key", "regional_certificate_arn", "regional_certificate_name"},
+				ConflictsWith: []string{"certificate_body", "certificate_chain", "certificate_name", "certificate_private_key", "regional_certificate_name"},
 			},
 
 			"cloudfront_domain_name": {
@@ -112,7 +112,7 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 			"regional_certificate_arn": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"certificate_arn", "certificate_body", "certificate_chain", "certificate_name", "certificate_private_key", "regional_certificate_name"},
+				ConflictsWith: []string{"certificate_body", "certificate_chain", "certificate_name", "certificate_private_key", "regional_certificate_name"},
 			},
 
 			"regional_certificate_name": {

--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e
 )
+
+go 1.13


### PR DESCRIPTION
Removed conflict between `certificateArn` and `regionalCertificateArn` to smooth out importing a real world situation.