### PR TITLE
[RM-3696] Spurious drift on Kinesis Firehose Delivery Streams

### DIFF
--- a/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -54,6 +54,13 @@ func s3ConfigurationSchema() *schema.Schema {
 		Type:     schema.TypeList,
 		MaxItems: 1,
 		Optional: true,
+		// Ignore the drift: s3_configuration.#: "1" => "0"
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			if old == "1" && new == "0" {
+				return true
+			}
+			return false
+		},
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"bucket_arn": {
@@ -64,19 +71,16 @@ func s3ConfigurationSchema() *schema.Schema {
 				"buffer_size": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					Default:  5,
 				},
 
 				"buffer_interval": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					Default:  300,
 				},
 
 				"compression_format": {
 					Type:     schema.TypeString,
 					Optional: true,
-					Default:  "UNCOMPRESSED",
 				},
 
 				"kms_key_arn": {


### PR DESCRIPTION
# Spurious drift on Kinesis Firehose Delivery Streams

From:

```
$ terraform plan -refresh=false

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_kinesis_firehose_delivery_stream.YXJuOmF3czpmaXJlaG9zZTp1cy1lYXN0LTE6MjA0MzkxNjQ0OTc2OmRlbGl2ZXJ5c3RyZWFtL2N1cnRpcy1kZWxpdmVyeS1zdHJlYW0
      s3_configuration.#:                    "1" => "0"
      s3_configuration.0.buffer_interval:    "0" => "300"
      s3_configuration.0.buffer_size:        "0" => "5"
      s3_configuration.0.compression_format: "" => "UNCOMPRESSED"


Plan: 0 to add, 1 to change, 0 to destroy.
```

To:

```bash
$ terraform plan -refresh=false

Initializing provider plugins...

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
```