### PR TITLE
[RM-3780] Toggle output logging

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -258,8 +257,6 @@ func (c *AWSClient) IsChinaCloud() bool {
 
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
-	// Disable logging, otherwise resource configuration is written to the logs
-	log.SetOutput(ioutil.Discard)
 	// Get the auth and region. This can fail if keys/regions were not
 	// specified and we're attempting to use the environment.
 	if c.SkipRegionValidation {

--- a/aws/config.go
+++ b/aws/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -257,6 +258,8 @@ func (c *AWSClient) IsChinaCloud() bool {
 
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
+	// Disable logging, otherwise resource configuration is written to the logs
+	log.SetOutput(ioutil.Discard)
 	// Get the auth and region. This can fail if keys/regions were not
 	// specified and we're attempting to use the environment.
 	if c.SkipRegionValidation {

--- a/aws/init.go
+++ b/aws/init.go
@@ -1,0 +1,15 @@
+package aws
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func init() {
+	// Disable logging unless debugging, otherwise resource configuration is written to the logs
+	val, ok := os.LookupEnv("TF_LOG")
+	if !ok || val == "" {
+		log.SetOutput(ioutil.Discard)
+	}
+}


### PR DESCRIPTION
## What

Adds an init function which will honor `TF_LOG` according to the [docs](https://www.terraform.io/docs/commands/environment-variables.html). Logs are simply log.Printf() statements which don't honor any log level setting. 

## Why

Every survey of customer accounts results in their resource configuration being logged to Cloudwatch Logs.

## Concerns

This file needs to be maintained going forward when upgrading providers. It's in a separate file so there should be no merging required. 