### PR TITLE
[RM-3816] Removed OS validation for SSM patch baseline

### DIFF
--- a/aws/resource_aws_ssm_patch_baseline.go
+++ b/aws/resource_aws_ssm_patch_baseline.go
@@ -130,11 +130,10 @@ func resourceAwsSsmPatchBaseline() *schema.Resource {
 			},
 
 			"operating_system": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      ssm.OperatingSystemWindows,
-				ValidateFunc: validation.StringInSlice(ssmPatchOSs, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  ssm.OperatingSystemWindows,
 			},
 
 			"approved_patches_compliance_level": {


### PR DESCRIPTION
Removed OS validation for SSM patch baseline.