### PR TITLE
[RM-3947] Support for Chinese characters in the description

### DIFF
--- a/aws/resource_aws_config_config_rule.go
+++ b/aws/resource_aws_config_config_rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -45,9 +46,19 @@ func resourceAwsConfigConfigRule() *schema.Resource {
 				Computed: true,
 			},
 			"description": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringLenBetween(0, 256),
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+					v, ok := i.(string)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+						return warnings, errors
+					}
+					if utf8.RuneCountInString(v) > 256 {
+						errors = append(errors, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, 0, 256, v))
+					}
+					return warnings, errors
+				},
 			},
 			"input_parameters": {
 				Type:         schema.TypeString,

--- a/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/aws/resource_aws_elastic_beanstalk_environment.go
@@ -970,9 +970,11 @@ func (e beanstalkEnvironmentError) Error() string {
 
 type beanstalkEnvironmentErrors []*beanstalkEnvironmentError
 
-func (e beanstalkEnvironmentErrors) Len() int           { return len(e) }
-func (e beanstalkEnvironmentErrors) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
-func (e beanstalkEnvironmentErrors) Less(i, j int) bool { return e[i].eventDate.Before(*e[j].eventDate) }
+func (e beanstalkEnvironmentErrors) Len() int      { return len(e) }
+func (e beanstalkEnvironmentErrors) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+func (e beanstalkEnvironmentErrors) Less(i, j int) bool {
+	return e[i].eventDate.Before(*e[j].eventDate)
+}
 
 func getBeanstalkEnvironmentErrors(conn *elasticbeanstalk.ElasticBeanstalk, environmentId string, t time.Time) (*multierror.Error, error) {
 	environmentErrors, err := conn.DescribeEvents(&elasticbeanstalk.DescribeEventsInput{

--- a/aws/resource_aws_iam_credential_report.go
+++ b/aws/resource_aws_iam_credential_report.go
@@ -209,12 +209,12 @@ func parseCsvCredentialReport(content []byte) (CredentialReport, error) {
 			PasswordLastChanged: line[header["password_last_changed"]],
 			MfaActive:           parseCsvBool(line[header["mfa_active"]]),
 			AccessKeys: []AccessKey{
-				AccessKey{
+				{
 					Active:       parseCsvBool(line[header["access_key_1_active"]]),
 					LastUsedDate: line[header["access_key_1_last_used_date"]],
 					LastRotated:  line[header["access_key_1_last_rotated"]],
 				},
-				AccessKey{
+				{
 					Active:       parseCsvBool(line[header["access_key_2_active"]]),
 					LastUsedDate: line[header["access_key_2_last_used_date"]],
 					LastRotated:  line[header["access_key_2_last_rotated"]],

--- a/aws/resource_aws_subnet.go
+++ b/aws/resource_aws_subnet.go
@@ -51,17 +51,17 @@ func resourceAwsSubnet() *schema.Resource {
 			},
 
 			"availability_zone": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"availability_zone_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 
 			"map_public_ip_on_launch": {


### PR DESCRIPTION
Chinese characters occupy a few more bytes than regular chars. `len()` won't work.

I ended up formatting the code `make ftm`.

There are a few tests failing. This was happening before this PR commits:
```
$ make test
==> Checking that code complies with gofmt requirements...
go test ./...  -timeout=120s -parallel=4
?   	github.com/terraform-providers/terraform-provider-aws	[no test files]
# github.com/terraform-providers/terraform-provider-aws/aws [github.com/terraform-providers/terraform-provider-aws/aws.test]
aws/resource_aws_s3_bucket_test.go:679:13: undefined: testAccAWSS3BucketConfigWithGrants
aws/resource_aws_s3_bucket_test.go:690:13: undefined: testAccAWSS3BucketConfigWithGrantsUpdate
aws/resource_aws_s3_bucket_test.go:704:13: undefined: testAccAWSS3BucketBasic
FAIL	github.com/terraform-providers/terraform-provider-aws/aws [build failed]
```