### PR TITLE
aws_acm_certificate: Increased the timeout

### DIFF
--- a/aws/resource_aws_acm_certificate.go
+++ b/aws/resource_aws_acm_certificate.go
@@ -226,7 +226,7 @@ func resourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) err
 		CertificateArn: aws.String(d.Id()),
 	}
 
-	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
+	return resource.Retry(time.Duration(5)*time.Minute, func() *resource.RetryError {
 		resp, err := acmconn.DescribeCertificate(params)
 
 		if err != nil {


### PR DESCRIPTION
See: https://github.com/terraform-providers/terraform-provider-aws/issues/8530#issuecomment-634375647

>  We have just merged an update to the aws_acm_certificate resource that will now allow it to wait for up to 5 minutes (instead of just 1 minute) for the ACM service to generate the DNS validation records for certificates with higher amounts of Subject Alternative Names or if this asynchronous ACM DNS validation value creation is otherwise being slow. 
