### PR TITLE
[RM-4399] Remove MaxItems from aws_api_gateway_domain_name.endpoint_configuration.types

### DIFF
--- a/aws/resource_aws_api_gateway_domain_name.go
+++ b/aws/resource_aws_api_gateway_domain_name.go
@@ -106,8 +106,6 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 							Type:     schema.TypeList,
 							Required: true,
 							MinItems: 1,
-							// BadRequestException: Cannot create an api with multiple Endpoint Types
-							MaxItems: 1,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{


### PR DESCRIPTION
API Gateway Domain Names support multiple endpoint types now.