### PR TITLE
[RM-4400] Replace HeadBucket and add descriptive 403 messages

### DIFF
--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -820,11 +820,13 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 	ignoreTagsConfig := meta.(*AWSClient).IgnoreTagsConfig
 
+	// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 	input := &s3.GetBucketEncryptionInput{
 		Bucket: aws.String(d.Id()),
 	}
 
 	err := resource.Retry(s3BucketCreationTimeout, func() *resource.RetryError {
+		// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 		_, err := s3conn.GetBucketEncryption(input)
 
 		if d.IsNewResource() && isAWSErrRequestFailureStatusCode(err, 404) {
@@ -835,6 +837,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			return resource.RetryableError(err)
 		}
 
+		// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 		if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
 			return resource.NonRetryableError(err)
 		}
@@ -843,6 +846,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if isResourceTimeoutError(err) {
+		// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 		_, err = s3conn.GetBucketEncryption(input)
 	}
 
@@ -852,6 +856,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting encryption configuration: %s", d.Id(), err)
 	}
@@ -875,6 +880,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				Bucket: aws.String(d.Id()),
 			})
 		})
+		// RM-4400 - more descriptive 403 errors
 		if isAWSErrRequestFailureStatusCode(err, 403) {
 			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting bucket policy: %s", d.Id(), err)
 		}
@@ -909,6 +915,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				Bucket: aws.String(d.Id()),
 			})
 		})
+		// RM-4400 - more descriptive 403 errors
 		if isAWSErrRequestFailureStatusCode(err, 403) {
 			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting ACL configuration: %s", d.Id(), err)
 		}
@@ -929,6 +936,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting CORS configuration: %s", d.Id(), err)
 	}
@@ -966,6 +974,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting website configuration: %s", d.Id(), err)
 	}
@@ -1038,6 +1047,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting versioning configuration: %s", d.Id(), err)
 	}
@@ -1074,6 +1084,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting acceleration configuration: %s", d.Id(), err)
 	}
@@ -1093,6 +1104,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting request payment configuration: %s", d.Id(), err)
 	}
@@ -1112,6 +1124,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting logging configuration: %s", d.Id(), err)
 	}
@@ -1144,6 +1157,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting lifecycle configuration: %s", d.Id(), err)
 	}
@@ -1278,6 +1292,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting replication configuration: %s", d.Id(), err)
 	}
@@ -1302,6 +1317,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting encryption configuration: %s", d.Id(), err)
 	}
@@ -1338,6 +1354,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		)
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting location: %s", d.Id(), err)
 	}
@@ -1389,6 +1406,7 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		return keyvaluetags.S3BucketListTags(s3conn, d.Id())
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while listing tags: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_s3_bucket.go
+++ b/aws/resource_aws_s3_bucket.go
@@ -852,6 +852,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting encryption configuration: %s", d.Id(), err)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error reading S3 Bucket (%s): %s", d.Id(), err)
 	}
@@ -871,6 +875,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				Bucket: aws.String(d.Id()),
 			})
 		})
+		if isAWSErrRequestFailureStatusCode(err, 403) {
+			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting bucket policy: %s", d.Id(), err)
+		}
 		log.Printf("[DEBUG] S3 bucket: %s, read policy: %v", d.Id(), pol)
 		if err != nil {
 			if err := d.Set("policy", ""); err != nil {
@@ -902,6 +909,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 				Bucket: aws.String(d.Id()),
 			})
 		})
+		if isAWSErrRequestFailureStatusCode(err, 403) {
+			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting ACL configuration: %s", d.Id(), err)
+		}
 		if err != nil {
 			return fmt.Errorf("error getting S3 Bucket (%s) ACL: %s", d.Id(), err)
 		}
@@ -918,6 +928,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting CORS configuration: %s", d.Id(), err)
+	}
+
 	if err != nil && !isAWSErr(err, "NoSuchCORSConfiguration", "") {
 		return fmt.Errorf("error getting S3 Bucket CORS configuration: %s", err)
 	}
@@ -950,6 +965,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting website configuration: %s", d.Id(), err)
+	}
+
 	if err != nil && !isAWSErr(err, "NotImplemented", "") && !isAWSErr(err, "NoSuchWebsiteConfiguration", "") {
 		return fmt.Errorf("error getting S3 Bucket website configuration: %s", err)
 	}
@@ -1017,6 +1037,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting versioning configuration: %s", d.Id(), err)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -1049,6 +1074,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting acceleration configuration: %s", d.Id(), err)
+	}
 	// Amazon S3 Transfer Acceleration might not be supported in the region
 	if err != nil && !isAWSErr(err, "MethodNotAllowed", "") && !isAWSErr(err, "UnsupportedArgument", "") {
 		return fmt.Errorf("error getting S3 Bucket acceleration configuration: %s", err)
@@ -1065,6 +1093,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		})
 	})
 
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting request payment configuration: %s", d.Id(), err)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket request payment: %s", err)
 	}
@@ -1079,6 +1111,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting logging configuration: %s", d.Id(), err)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket logging: %s", err)
@@ -1107,6 +1143,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting lifecycle configuration: %s", d.Id(), err)
+	}
+
 	if err != nil && !isAWSErr(err, "NoSuchLifecycleConfiguration", "") {
 		return err
 	}
@@ -1236,6 +1277,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting replication configuration: %s", d.Id(), err)
+	}
+
 	if err != nil && !isAWSErr(err, "ReplicationConfigurationNotFoundError", "") {
 		return fmt.Errorf("error getting S3 Bucket replication: %s", err)
 	}
@@ -1255,6 +1301,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			Bucket: aws.String(d.Id()),
 		})
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting encryption configuration: %s", d.Id(), err)
+	}
+
 	if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
 		return fmt.Errorf("error getting S3 Bucket encryption: %s", err)
 	}
@@ -1286,6 +1337,11 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			},
 		)
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting location: %s", d.Id(), err)
+	}
+
 	if err != nil {
 		return fmt.Errorf("error getting S3 Bucket location: %s", err)
 	}
@@ -1332,6 +1388,10 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	tags, err := retryOnAwsCode(s3.ErrCodeNoSuchBucket, func() (interface{}, error) {
 		return keyvaluetags.S3BucketListTags(s3conn, d.Id())
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while listing tags: %s", d.Id(), err)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error listing tags for S3 Bucket (%s): %s", d.Id(), err)

--- a/aws/resource_aws_s3_bucket_analytics_configuration.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration.go
@@ -183,6 +183,11 @@ func resourceAwsS3BucketAnalyticsConfigurationRead(d *schema.ResourceData, meta 
 
 	log.Printf("[DEBUG] Reading S3 bucket analytics configuration: %s", input)
 	output, err := conn.GetBucketAnalyticsConfiguration(input)
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting analytics configuration (%s): %s", bucket, name, err)
+	}
+
 	if err != nil {
 		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
 			log.Printf("[WARN] %s S3 bucket analytics configuration not found, removing from state.", d.Id())

--- a/aws/resource_aws_s3_bucket_analytics_configuration.go
+++ b/aws/resource_aws_s3_bucket_analytics_configuration.go
@@ -184,6 +184,7 @@ func resourceAwsS3BucketAnalyticsConfigurationRead(d *schema.ResourceData, meta 
 	log.Printf("[DEBUG] Reading S3 bucket analytics configuration: %s", input)
 	output, err := conn.GetBucketAnalyticsConfiguration(input)
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting analytics configuration (%s): %s", bucket, name, err)
 	}

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -311,6 +311,11 @@ func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) 
 		}
 		return nil
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting inventory configuration (%s): %s", bucket, name, err)
+	}
+
 	if isResourceTimeoutError(err) {
 		output, err = conn.GetBucketInventoryConfiguration(input)
 		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {

--- a/aws/resource_aws_s3_bucket_inventory.go
+++ b/aws/resource_aws_s3_bucket_inventory.go
@@ -312,6 +312,7 @@ func resourceAwsS3BucketInventoryRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting inventory configuration (%s): %s", bucket, name, err)
 	}

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -141,6 +141,7 @@ func resourceAwsS3BucketMetricRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Reading S3 bucket metrics configuration: %s", input)
 	output, err := conn.GetBucketMetricsConfiguration(input)
 	if err != nil {
+		// RM-4400 - more descriptive 403 errors
 		if isAWSErrRequestFailureStatusCode(err, 403) {
 			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting metrics configuration (%s): %s", bucket, name, err)
 		}

--- a/aws/resource_aws_s3_bucket_metric.go
+++ b/aws/resource_aws_s3_bucket_metric.go
@@ -141,6 +141,10 @@ func resourceAwsS3BucketMetricRead(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] Reading S3 bucket metrics configuration: %s", input)
 	output, err := conn.GetBucketMetricsConfiguration(input)
 	if err != nil {
+		if isAWSErrRequestFailureStatusCode(err, 403) {
+			return fmt.Errorf("permissions error on S3 Bucket (%s) while getting metrics configuration (%s): %s", bucket, name, err)
+		}
+
 		if isAWSErr(err, s3.ErrCodeNoSuchBucket, "") || isAWSErr(err, "NoSuchConfiguration", "The specified configuration does not exist.") {
 			log.Printf("[WARN] %s S3 bucket metrics configuration not found, removing from state.", d.Id())
 			d.SetId("")

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -361,6 +361,10 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 		Bucket: aws.String(d.Id()),
 	})
 	if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
+		if isAWSErrRequestFailureStatusCode(err, 403) {
+			return fmt.Errorf("permissions error on S3 Bucket (%s) while verifying bucket existence: %s", d.Id(), err)
+		}
+
 		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
 			log.Printf("[WARN] S3 Bucket (%s) not found, error code (404)", d.Id())
 			d.SetId("")
@@ -376,6 +380,11 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 	notificationConfigs, err := s3conn.GetBucketNotificationConfiguration(&s3.GetBucketNotificationConfigurationRequest{
 		Bucket: aws.String(d.Id()),
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting notification configuration: %s", d.Id(), err)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -357,10 +357,10 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 	s3conn := meta.(*AWSClient).s3conn
 
 	var err error
-	_, err = s3conn.HeadBucket(&s3.HeadBucketInput{
+	_, err = s3conn.GetBucketEncryption(&s3.GetBucketEncryptionInput{
 		Bucket: aws.String(d.Id()),
 	})
-	if err != nil {
+	if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
 		if awsError, ok := err.(awserr.RequestFailure); ok && awsError.StatusCode() == 404 {
 			log.Printf("[WARN] S3 Bucket (%s) not found, error code (404)", d.Id())
 			d.SetId("")

--- a/aws/resource_aws_s3_bucket_notification.go
+++ b/aws/resource_aws_s3_bucket_notification.go
@@ -357,10 +357,13 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 	s3conn := meta.(*AWSClient).s3conn
 
 	var err error
+	// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 	_, err = s3conn.GetBucketEncryption(&s3.GetBucketEncryptionInput{
 		Bucket: aws.String(d.Id()),
 	})
+	// RM-4400 - remove HeadBucket because it requires s3:ListBucket permission
 	if err != nil && !isAWSErr(err, "ServerSideEncryptionConfigurationNotFoundError", "encryption configuration was not found") {
+		// RM-4400 - more descriptive 403 errors
 		if isAWSErrRequestFailureStatusCode(err, 403) {
 			return fmt.Errorf("permissions error on S3 Bucket (%s) while verifying bucket existence: %s", d.Id(), err)
 		}
@@ -381,6 +384,7 @@ func resourceAwsS3BucketNotificationRead(d *schema.ResourceData, meta interface{
 		Bucket: aws.String(d.Id()),
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting notification configuration: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_s3_bucket_policy.go
+++ b/aws/resource_aws_s3_bucket_policy.go
@@ -83,6 +83,10 @@ func resourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) err
 		Bucket: aws.String(d.Id()),
 	})
 
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting bucket policy: %s", d.Id(), err)
+	}
+
 	v := ""
 	if err == nil && pol.Policy != nil {
 		v = *pol.Policy

--- a/aws/resource_aws_s3_bucket_policy.go
+++ b/aws/resource_aws_s3_bucket_policy.go
@@ -83,6 +83,7 @@ func resourceAwsS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) err
 		Bucket: aws.String(d.Id()),
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting bucket policy: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_s3_bucket_public_access_block.go
+++ b/aws/resource_aws_s3_bucket_public_access_block.go
@@ -121,6 +121,7 @@ func resourceAwsS3BucketPublicAccessBlockRead(d *schema.ResourceData, meta inter
 		return nil
 	})
 
+	// RM-4400 - more descriptive 403 errors
 	if isAWSErrRequestFailureStatusCode(err, 403) {
 		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting public access block configuration: %s", d.Id(), err)
 	}

--- a/aws/resource_aws_s3_bucket_public_access_block.go
+++ b/aws/resource_aws_s3_bucket_public_access_block.go
@@ -120,6 +120,11 @@ func resourceAwsS3BucketPublicAccessBlockRead(d *schema.ResourceData, meta inter
 
 		return nil
 	})
+
+	if isAWSErrRequestFailureStatusCode(err, 403) {
+		return fmt.Errorf("permissions error on S3 Bucket (%s) while getting public access block configuration: %s", d.Id(), err)
+	}
+
 	if isResourceTimeoutError(err) {
 		output, err = s3conn.GetPublicAccessBlock(input)
 	}


### PR DESCRIPTION
This PR replaces the `HeadBucket` operation in `resource_aws_s3_bucket` and `resource_aws_s3_bucket_notification` with `GetBucketEncryption` to remove the need for `s3:ListBucket` permission.

It also adds more descriptive messages for 403 errors from S3 operations.