### PR TITLE
[RM-4561] Remove Validation on EFS Volume Transit Encryption Port

### DIFF
--- a/aws/resource_aws_ecs_task_definition.go
+++ b/aws/resource_aws_ecs_task_definition.go
@@ -214,10 +214,10 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 										}, false),
 									},
 									"transit_encryption_port": {
-										Type:         schema.TypeInt,
-										ForceNew:     true,
-										Optional:     true,
-										ValidateFunc: validation.IsPortNumber,
+										Type:     schema.TypeInt,
+										ForceNew: true,
+										Optional: true,
+										// ValidateFunc: validation.IsPortNumber,
 									},
 									"authorization_config": {
 										Type:     schema.TypeList,


### PR DESCRIPTION
Remove validation for transit encryption port on efs volume mounts for ECS task definitions.  `0` is not an acceptable value for a port, but it is the default value returned by the survey when no port is specifically define.