### PR TITLE
[RM-4541] Add is_default attribute to VPCs

### DIFF
--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -110,6 +110,10 @@ func resourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"is_default": {
+				Type: schema.TypeBool,
+			},
+
 			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -250,6 +254,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", vpc.CidrBlock)
 	d.Set("dhcp_options_id", vpc.DhcpOptionsId)
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
+	d.Set("is_default", vpc.IsDefault)
 
 	// ARN
 	arn := arn.ARN{


### PR DESCRIPTION
Adds the `is_default` attribute to VPCs. I did not observe the `aws_default_vpc` type used in scans even though I created a default VPC for my testing. These changes are in support of an A&E request which requires checking for a default VPC.