### PR TITLE
[RM-4541] Update is_default schema for aws_vpc

### DIFF
--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -98,6 +98,11 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
+			"is_default": {
+				Type: schema.TypeBool,
+				Computed: true,
+			}
+
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -182,6 +187,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
+	d.Set("is_default", vpc.IsDefault)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/data_source_aws_vpc.go
+++ b/aws/data_source_aws_vpc.go
@@ -98,11 +98,6 @@ func dataSourceAwsVpc() *schema.Resource {
 				Computed: true,
 			},
 
-			"is_default": {
-				Type: schema.TypeBool,
-				Computed: true,
-			}
-
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -187,7 +182,6 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
-	d.Set("is_default", vpc.IsDefault)
 
 	if err := d.Set("tags", keyvaluetags.Ec2KeyValueTags(vpc.Tags).IgnoreAws().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)

--- a/aws/resource_aws_vpc.go
+++ b/aws/resource_aws_vpc.go
@@ -111,7 +111,8 @@ func resourceAwsVpc() *schema.Resource {
 			},
 
 			"is_default": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
+				Computed: true,
 			},
 
 			"arn": {


### PR DESCRIPTION
Updates the schema for aws_vpc since the field cannot be set manually