### PR TITLE
[RM-4661] Handle InvalidVolume error gracefully

### DIFF
--- a/aws/resource_aws_instance.go
+++ b/aws/resource_aws_instance.go
@@ -1550,7 +1550,12 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 	volResp, err := conn.DescribeVolumes(&ec2.DescribeVolumesInput{
 		VolumeIds: volIDs,
 	})
+
 	if err != nil {
+		if isAWSErr(err, "InvalidVolume.NotFound", "does not exist") {
+			log.Print("[WARN] Unable to describe volumes attached to instance")
+			return blockDevices, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Handle InvalidVolume error gracefully when describing EC2 instance volumes, allowing the resource to still be refreshed