### PR TITLE
Extend IAM Credential Report Timeout

### DIFF
--- a/aws/resource_aws_iam_credential_report.go
+++ b/aws/resource_aws_iam_credential_report.go
@@ -100,7 +100,7 @@ func resourceAwsIamCredentialReportRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	return resource.Retry(time.Duration(1)*time.Minute, func() *resource.RetryError {
+	return resource.Retry(time.Duration(3)*time.Minute, func() *resource.RetryError {
 		// Prepare a request to actually get the credential report.
 		getReportOutput, err := iamconn.GetCredentialReport(nil)
 		if err != nil {


### PR DESCRIPTION
## What

Extends the IAM Credential Report timeout for generating a report from 1 to 3 minutes.

## Why

An account with thousands of users takes longer than a minute.