### PR TITLE
[RM-4926] Add resources to source export in zim config

### DIFF
--- a/component.yaml
+++ b/component.yaml
@@ -2,6 +2,10 @@ name: terraform-provider-aws
 kind: go-library
 exports:
   source:
+    resources:
+    - go.mod
+    - go.sum
+    - "**/*.go"
     ignore:
     - "**/*_test.go"
     - "vendor/**/*.go"


### PR DESCRIPTION
This PR adds a `resources` block to the `source` export in the zim config.