### PR TITLE
[RM-6664] Add service coverage for advanced event selectors to aws_cloudtrail

### DIFF
--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -442,7 +443,9 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 	})
 	if err != nil {
 		if !isAWSErr(err, cloudtrail.ErrCodeInsightNotEnabledException, "") {
-			return fmt.Errorf("error getting Cloud Trail (%s) Insight Selectors: %w", d.Id(), err)
+			if !strings.Contains(err.Error(), "AccessDeniedException") {
+				return fmt.Errorf("error getting Cloud Trail (%s) Insight Selectors: %w", d.Id(), err)
+			}
 		}
 	}
 	if insightSelectors != nil {

--- a/aws/resource_aws_cloudtrail.go
+++ b/aws/resource_aws_cloudtrail.go
@@ -13,6 +13,40 @@ import (
 	"github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags"
 )
 
+const (
+	ResourceTypeDynamoDBTable  = "AWS::DynamoDB::Table"
+	ResourceTypeLambdaFunction = "AWS::Lambda::Function"
+	ResourceTypeS3Object       = "AWS::S3::Object"
+)
+
+func ResourceType_Values() []string {
+	return []string{
+		ResourceTypeDynamoDBTable,
+		ResourceTypeLambdaFunction,
+		ResourceTypeS3Object,
+	}
+}
+
+const (
+	FieldEventCategory = "eventCategory"
+	FieldEventName     = "eventName"
+	FieldEventSource   = "eventSource"
+	FieldReadOnly      = "readOnly"
+	FieldResourcesARN  = "resources.ARN"
+	FieldResourcesType = "resources.type"
+)
+
+func Field_Values() []string {
+	return []string{
+		FieldEventCategory,
+		FieldEventName,
+		FieldEventSource,
+		FieldReadOnly,
+		FieldResourcesARN,
+		FieldResourcesType,
+	}
+}
+
 func resourceAwsCloudTrail() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsCloudTrailCreate,
@@ -54,6 +88,10 @@ func resourceAwsCloudTrail() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+			"insight_selector": {
+				Type:     schema.TypeList,
+				Optional: true,
 			},
 			"is_multi_region_trail": {
 				Type:     schema.TypeBool,
@@ -110,7 +148,7 @@ func resourceAwsCloudTrail() *schema.Resource {
 									"type": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"AWS::S3::Object", "AWS::Lambda::Function"}, false),
+										ValidateFunc: validation.StringInSlice(ResourceType_Values(), false),
 									},
 									"values": {
 										Type:     schema.TypeList,
@@ -120,6 +158,88 @@ func resourceAwsCloudTrail() *schema.Resource {
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+			"advanced_event_selector": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"event_selector"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_selector": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ends_with": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+									"equals": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+									"field": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice(Field_Values(), false),
+									},
+									"not_ends_with": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+									"not_equals": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+									"not_starts_with": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+									"starts_with": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MinItems: 1,
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.StringLenBetween(1, 2048),
+										},
+									},
+								},
+							},
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(0, 1000),
 						},
 					},
 				},
@@ -219,6 +339,18 @@ func resourceAwsCloudTrailCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	if _, ok := d.GetOk("advanced_event_selector"); ok {
+		if err := cloudTrailSetAdvancedEventSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
+	if _, ok := d.GetOk("insight_selector"); ok {
+		if err := cloudTrailSetInsightSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
 	return resourceAwsCloudTrailRead(d, meta)
 }
 
@@ -298,6 +430,25 @@ func resourceAwsCloudTrailRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set("event_selector", flattenAwsCloudTrailEventSelector(eventSelectorsOut.EventSelectors)); err != nil {
 		return err
+	}
+
+	if err := d.Set("advanced_event_selector", flattenAwsCloudTrailAdvancedEventSelector(eventSelectorsOut.AdvancedEventSelectors)); err != nil {
+		return err
+	}
+
+	// Get InsightSelectors
+	insightSelectors, err := conn.GetInsightSelectors(&cloudtrail.GetInsightSelectorsInput{
+		TrailName: aws.String(d.Id()),
+	})
+	if err != nil {
+		if !isAWSErr(err, cloudtrail.ErrCodeInsightNotEnabledException, "") {
+			return fmt.Errorf("error getting Cloud Trail (%s) Insight Selectors: %w", d.Id(), err)
+		}
+	}
+	if insightSelectors != nil {
+		if err := d.Set("insight_selector", flattenAwsCloudTrailInsightSelector(insightSelectors.InsightSelectors)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -383,6 +534,20 @@ func resourceAwsCloudTrailUpdate(d *schema.ResourceData, meta interface{}) error
 	if !d.IsNewResource() && d.HasChange("event_selector") {
 		log.Printf("[DEBUG] Updating event selector on CloudTrail: %s", input)
 		if err := cloudTrailSetEventSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("advanced_event_selector") {
+		log.Printf("[DEBUG] Updating advanced event selector on CloudTrail: %s", input)
+		if err := cloudTrailSetAdvancedEventSelectors(conn, d); err != nil {
+			return err
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("insight_selector") {
+		log.Printf("[DEBUG] Updating insight selector on CloudTrail: %s", input)
+		if err := cloudTrailSetInsightSelectors(conn, d); err != nil {
 			return err
 		}
 	}
@@ -547,4 +712,207 @@ func flattenAwsCloudTrailEventSelectorDataResource(configured []*cloudtrail.Data
 	}
 
 	return dataResources
+}
+
+func cloudTrailSetAdvancedEventSelectors(conn *cloudtrail.CloudTrail, d *schema.ResourceData) error {
+	input := &cloudtrail.PutEventSelectorsInput{
+		TrailName: aws.String(d.Id()),
+	}
+
+	advancedEventSelectors := expandAwsCloudTrailAdvancedEventSelector(d.Get("advanced_event_selector").([]interface{}))
+
+	input.AdvancedEventSelectors = advancedEventSelectors
+
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("Error validate CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	_, err := conn.PutEventSelectors(input)
+	if err != nil {
+		return fmt.Errorf("Error set advanced event selector on CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandAwsCloudTrailAdvancedEventSelector(configured []interface{}) []*cloudtrail.AdvancedEventSelector {
+	advancedEventSelectors := make([]*cloudtrail.AdvancedEventSelector, 0, len(configured))
+
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+		fieldSelectors := expandAwsCloudTrailAdvancedEventSelectorFieldSelector(data["field_selector"].(*schema.Set))
+
+		aes := &cloudtrail.AdvancedEventSelector{
+			Name:           aws.String(data["name"].(string)),
+			FieldSelectors: fieldSelectors,
+		}
+
+		advancedEventSelectors = append(advancedEventSelectors, aes)
+
+	}
+
+	return advancedEventSelectors
+
+}
+
+func expandAwsCloudTrailAdvancedEventSelectorFieldSelector(configured *schema.Set) []*cloudtrail.AdvancedFieldSelector {
+	fieldSelectors := make([]*cloudtrail.AdvancedFieldSelector, 0, configured.Len())
+
+	for _, raw := range configured.List() {
+		data := raw.(map[string]interface{})
+		fieldSelector := &cloudtrail.AdvancedFieldSelector{
+			Field: aws.String(data["field"].(string)),
+		}
+
+		if v, ok := data["equals"]; ok && len(v.([]interface{})) > 0 {
+			equals := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				equals[i] = aws.String(str)
+			}
+			fieldSelector.Equals = equals
+		}
+
+		if v, ok := data["not_equals"]; ok && len(v.([]interface{})) > 0 {
+			notEquals := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				notEquals[i] = aws.String(str)
+			}
+			fieldSelector.NotEquals = notEquals
+		}
+
+		if v, ok := data["starts_with"]; ok && len(v.([]interface{})) > 0 {
+			startsWith := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				startsWith[i] = aws.String(str)
+			}
+			fieldSelector.StartsWith = startsWith
+		}
+
+		if v, ok := data["not_starts_with"]; ok && len(v.([]interface{})) > 0 {
+			notStartsWith := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				notStartsWith[i] = aws.String(str)
+			}
+			fieldSelector.NotStartsWith = notStartsWith
+		}
+
+		if v, ok := data["ends_with"]; ok && len(v.([]interface{})) > 0 {
+			endsWith := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				endsWith[i] = aws.String(str)
+			}
+			fieldSelector.EndsWith = endsWith
+		}
+
+		if v, ok := data["not_ends_with"]; ok && len(v.([]interface{})) > 0 {
+			notEndsWith := make([]*string, len(v.([]interface{})))
+			for i, vv := range v.([]interface{}) {
+				str := vv.(string)
+				notEndsWith[i] = aws.String(str)
+			}
+			fieldSelector.NotEndsWith = notEndsWith
+		}
+
+		fieldSelectors = append(fieldSelectors, fieldSelector)
+	}
+
+	return fieldSelectors
+}
+
+func flattenAwsCloudTrailAdvancedEventSelector(configured []*cloudtrail.AdvancedEventSelector) []map[string]interface{} {
+	advancedEventSelectors := make([]map[string]interface{}, 0, len(configured))
+
+	for _, raw := range configured {
+		item := make(map[string]interface{})
+		item["name"] = aws.StringValue(raw.Name)
+		item["field_selector"] = flattenAwsCloudTrailAdvancedEventSelectorFieldSelector(raw.FieldSelectors)
+
+		advancedEventSelectors = append(advancedEventSelectors, item)
+	}
+
+	return advancedEventSelectors
+}
+
+func flattenAwsCloudTrailAdvancedEventSelectorFieldSelector(configured []*cloudtrail.AdvancedFieldSelector) []map[string]interface{} {
+	fieldSelectors := make([]map[string]interface{}, 0, len(configured))
+
+	for _, raw := range configured {
+		item := make(map[string]interface{})
+		item["field"] = aws.StringValue(raw.Field)
+		if raw.Equals != nil {
+			item["equals"] = flattenStringList(raw.Equals)
+		}
+		if raw.NotEquals != nil {
+			item["not_equals"] = flattenStringList(raw.NotEquals)
+		}
+		if raw.StartsWith != nil {
+			item["starts_with"] = flattenStringList(raw.StartsWith)
+		}
+		if raw.NotStartsWith != nil {
+			item["not_starts_with"] = flattenStringList(raw.NotStartsWith)
+		}
+		if raw.EndsWith != nil {
+			item["ends_with"] = flattenStringList(raw.EndsWith)
+		}
+		if raw.NotEndsWith != nil {
+			item["not_ends_with"] = flattenStringList(raw.NotEndsWith)
+		}
+
+		fieldSelectors = append(fieldSelectors, item)
+	}
+
+	return fieldSelectors
+}
+
+func cloudTrailSetInsightSelectors(conn *cloudtrail.CloudTrail, d *schema.ResourceData) error {
+	input := &cloudtrail.PutInsightSelectorsInput{
+		TrailName: aws.String(d.Id()),
+	}
+
+	insightSelector := expandAwsCloudTrailInsightSelector(d.Get("insight_selector").([]interface{}))
+	input.InsightSelectors = insightSelector
+
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("Error validate CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	_, err := conn.PutInsightSelectors(input)
+	if err != nil {
+		return fmt.Errorf("Error set insight selector on CloudTrail (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func expandAwsCloudTrailInsightSelector(configured []interface{}) []*cloudtrail.InsightSelector {
+	insightSelectors := make([]*cloudtrail.InsightSelector, 0, len(configured))
+
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+
+		is := &cloudtrail.InsightSelector{
+			InsightType: aws.String(data["insight_type"].(string)),
+		}
+		insightSelectors = append(insightSelectors, is)
+	}
+
+	return insightSelectors
+}
+
+func flattenAwsCloudTrailInsightSelector(configured []*cloudtrail.InsightSelector) []map[string]interface{} {
+	insightSelectors := make([]map[string]interface{}, 0, len(configured))
+
+	for _, raw := range configured {
+		item := make(map[string]interface{})
+		item["insight_type"] = aws.StringValue(raw.InsightType)
+
+		insightSelectors = append(insightSelectors, item)
+	}
+
+	return insightSelectors
 }


### PR DESCRIPTION
## Description

Update aws_cloudtrail resource with support for advanced event selector fields. Code was ported from the Terraform pull request that added this support.

## Types of Changes

- [x] New feature
- [ ] Breaking change
- [ ] Non-functional (docs, refactoring, etc)
- [ ] This change requires a documentation update

## JIRA

https://luminal.atlassian.net/browse/RM-6664

## Affected Components

- survey_aws_region

## Testing

- Did a deploy and verified via the viz and a statefile that the advanced event selector settings were present, and that there were no permission errors

## Checklist

- [ ] Unit tests
- [ ] E2E tests
- [ ] Internal docs
- [ ] End-user docs
- [ ] Regenerated files
