### PR TITLE
[CLOUD-46] Added disable_execute_api_endpoint to aws_api_gateway_rest_api and aw…

### DIFF
--- a/aws/resource_aws_api_gateway_rest_api.go
+++ b/aws/resource_aws_api_gateway_rest_api.go
@@ -64,6 +64,12 @@ func resourceAwsApiGatewayRestApi() *schema.Resource {
 				Optional: true,
 			},
 
+			"disable_execute_api_endpoint": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"minimum_compression_size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -149,6 +155,10 @@ func resourceAwsApiGatewayRestApiCreate(d *schema.ResourceData, meta interface{}
 		params.ApiKeySource = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("disable_execute_api_endpoint"); ok {
+		params.DisableExecuteApiEndpoint = aws.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("policy"); ok && v.(string) != "" {
 		params.Policy = aws.String(v.(string))
 	}
@@ -226,6 +236,7 @@ func resourceAwsApiGatewayRestApiRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("name", api.Name)
 	d.Set("description", api.Description)
 	d.Set("api_key_source", api.ApiKeySource)
+	d.Set("disable_execute_api_endpoint", api.DisableExecuteApiEndpoint)
 
 	// The API returns policy as an escaped JSON string
 	// {\\\"Version\\\":\\\"2012-10-17\\\",...}
@@ -306,6 +317,14 @@ func resourceAwsApiGatewayRestApiUpdateOperations(d *schema.ResourceData) []*api
 			Op:    aws.String(apigateway.OpReplace),
 			Path:  aws.String("/apiKeySource"),
 			Value: aws.String(d.Get("api_key_source").(string)),
+		})
+	}
+
+	if d.HasChange("disable_execute_api_endpoint") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String(apigateway.OpReplace),
+			Path:  aws.String("/disableExecuteApiEndpoint"),
+			Value: aws.String(d.Get("disable_execute_api_endpoint").(string)),
 		})
 	}
 

--- a/aws/resource_aws_apigatewayv2_api.go
+++ b/aws/resource_aws_apigatewayv2_api.go
@@ -92,6 +92,10 @@ func resourceAwsApiGatewayV2Api() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 1024),
 			},
+			"disable_execute_api_endpoint": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"execution_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -156,6 +160,9 @@ func resourceAwsApiGatewayV2ApiCreate(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("description"); ok {
 		req.Description = aws.String(v.(string))
 	}
+	if v, ok := d.GetOk("disable_execute_api_endpoint"); ok {
+		req.DisableExecuteApiEndpoint = aws.Bool(v.(bool))
+	}
 	if v, ok := d.GetOk("route_key"); ok {
 		req.RouteKey = aws.String(v.(string))
 	}
@@ -209,6 +216,7 @@ func resourceAwsApiGatewayV2ApiRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("error setting cors_configuration: %s", err)
 	}
 	d.Set("description", resp.Description)
+	d.Set("disable_execute_api_endpoint", resp.DisableExecuteApiEndpoint)
 	executionArn := arn.ARN{
 		Partition: meta.(*AWSClient).partition,
 		Service:   "execute-api",
@@ -261,6 +269,9 @@ func resourceAwsApiGatewayV2ApiUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 		if d.HasChange("description") {
 			req.Description = aws.String(d.Get("description").(string))
+		}
+		if d.HasChange("disable_execute_api_endpoint") {
+			req.DisableExecuteApiEndpoint = aws.Bool(d.Get("disable_execute_api_endpoint").(bool))
 		}
 		if d.HasChange("name") {
 			req.Name = aws.String(d.Get("name").(string))


### PR DESCRIPTION
## Description

Added disable_execute_api_endpoint field to aws_api_gateway_rest_api and aws_apigatewayv2_api resources. Ported update from most recent version of AWS Terraform provider (v4.5.0).

## Types of Changes

- [ ] Database migration
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Non-functional (docs, refactoring, etc)
- [ ] This change requires a documentation update

## JIRA

https://snyksec.atlassian.net/browse/CLOUD-46

## Affected Components

## Testing

Deployed branch to dev instance. Ran scan and verified presence of new field in visualizer. Verified that drift works correctly with the field.

## Checklist

- [ ] Unit tests
- [ ] E2E tests
- [ ] Internal docs
- [ ] End-user docs
- [ ] Regenerated files
