### PR TITLE
chore: upgade http2 hpack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.org/x/net v0.6.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect


### PR DESCRIPTION
There is a replace directive to upgrade it to 0.8.0, but apparently that will only upgrade the main module, not any submodules, and there is a vulnerability in the hpack submodule.