### PR TITLE
fix: partial scan errors [CLOUD-1305] 

### DIFF
--- a/aws/resource_aws_cloudformation_stack.go
+++ b/aws/resource_aws_cloudformation_stack.go
@@ -302,7 +302,9 @@ func resourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface{}
 
 	template, err := normalizeCloudFormationTemplate(*out.TemplateBody)
 	if err != nil {
-		return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
+		// CLOUD-1305
+		template = *out.TemplateBody
+		// return fmt.Errorf("template body contains an invalid JSON or YAML: %s", err)
 	}
 	d.Set("template_body", template)
 

--- a/aws/resource_aws_directory_service_directory.go
+++ b/aws/resource_aws_directory_service_directory.go
@@ -500,7 +500,7 @@ func resourceAwsDirectoryServiceDirectoryRead(d *schema.ResourceData, meta inter
 
 	if aws.StringValue(dir.Type) == directoryservice.DirectoryTypeAdconnector {
 		d.Set("security_group_id", aws.StringValue(dir.ConnectSettings.SecurityGroupId))
-	} else {
+	} else if dir.VpcSettings != nil { // CLOUD-1305
 		d.Set("security_group_id", aws.StringValue(dir.VpcSettings.SecurityGroupId))
 	}
 


### PR DESCRIPTION
 This PR contains fixes for two issues that resulted in partial scan errors:
  
* A panic from AWS Directory Service directories with nil VpcSettings
* An error from malformed CloudFormation templates
