### PR TITLE
fix: [CENTEX-736] enable HidePassword option for aws_glue_connection

### DIFF
--- a/aws/resource_aws_glue_connection.go
+++ b/aws/resource_aws_glue_connection.go
@@ -126,8 +126,9 @@ func resourceAwsGlueConnectionRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	input := &glue.GetConnectionInput{
-		CatalogId: aws.String(catalogID),
-		Name:      aws.String(connectionName),
+		CatalogId:    aws.String(catalogID),
+		Name:         aws.String(connectionName),
+		HidePassword: aws.Bool(true), // CENTEX-736
 	}
 
 	log.Printf("[DEBUG] Reading Glue Connection: %s", input)


### PR DESCRIPTION
This PR enables the `HidePassword` option on the read request for `aws_glue_connection` resources. This option causes AWS to exclude the connection password (whether encrypted or unencrypted) from the response.